### PR TITLE
 Windows (mingw-w64) support: Win32 lib ports, POSIX-free python utils, and an ODR fix in the Configuration<> header   

### DIFF
--- a/lib/database.cc
+++ b/lib/database.cc
@@ -9,7 +9,11 @@
  */
 #include <prjxray/database.h>
 
+#ifdef _WIN32
+#include <windows.h>
+#else
 #include <glob.h>
+#endif
 
 #include <memory>
 
@@ -23,6 +27,25 @@ std::vector<std::unique_ptr<prjxray::SegbitsFileReader>> Database::segbits()
     const {
 	std::vector<std::unique_ptr<prjxray::SegbitsFileReader>> segbits;
 
+#ifdef _WIN32
+	const std::string pattern =
+	    absl::StrCat(db_path_, "/", kSegbitsGlobPattern);
+	WIN32_FIND_DATAA find_data;
+	HANDLE handle = FindFirstFileA(pattern.c_str(), &find_data);
+	if (handle == INVALID_HANDLE_VALUE) {
+		return {};
+	}
+
+	do {
+		auto this_segbit = SegbitsFileReader::InitWithFile(
+		    absl::StrCat(db_path_, "/", find_data.cFileName));
+		if (this_segbit) {
+			segbits.emplace_back(std::move(this_segbit));
+		}
+	} while (FindNextFileA(handle, &find_data));
+
+	FindClose(handle);
+#else
 	glob_t segbits_glob_results;
 	int ret = glob(absl::StrCat(db_path_, "/", kSegbitsGlobPattern).c_str(),
 	               GLOB_NOSORT | GLOB_TILDE, NULL, &segbits_glob_results);
@@ -39,6 +62,7 @@ std::vector<std::unique_ptr<prjxray::SegbitsFileReader>> Database::segbits()
 	}
 
 	globfree(&segbits_glob_results);
+#endif
 
 	return segbits;
 }

--- a/lib/include/prjxray/xilinx/configuration.h
+++ b/lib/include/prjxray/xilinx/configuration.h
@@ -75,6 +75,44 @@ class Configuration {
 	FrameMap frames_;
 };
 
+// The explicit specializations below are defined in configuration.cc.
+// They must be declared before use in every translation unit
+// ([temp.expl.spec]): without these declarations, a TU that calls
+// createType2ConfigurationPacketData<Spartan6> instantiates the primary
+// template defined further down in this header, and that COMDAT copy
+// collides with the strong definition from configuration.cc when linking
+// with mingw-w64 ld ("multiple definition"); ELF linkers silently
+// resolve the collision in favour of the strong symbol.
+template <>
+Configuration<Spartan6>::PacketData
+Configuration<Spartan6>::createType2ConfigurationPacketData(
+    const Frames<Spartan6>::Frames2Data& frames,
+    absl::optional<Spartan6::Part>& part);
+
+template <>
+void Configuration<Spartan6>::createConfigurationPackage(
+    Spartan6::ConfigurationPackage& out_packets,
+    const PacketData& packet_data,
+    absl::optional<Spartan6::Part>& part);
+
+template <>
+void Configuration<Series7>::createConfigurationPackage(
+    Series7::ConfigurationPackage& out_packets,
+    const PacketData& packet_data,
+    absl::optional<Series7::Part>& part);
+
+template <>
+void Configuration<UltraScale>::createConfigurationPackage(
+    UltraScale::ConfigurationPackage& out_packets,
+    const PacketData& packet_data,
+    absl::optional<UltraScale::Part>& part);
+
+template <>
+void Configuration<UltraScalePlus>::createConfigurationPackage(
+    UltraScalePlus::ConfigurationPackage& out_packets,
+    const PacketData& packet_data,
+    absl::optional<UltraScalePlus::Part>& part);
+
 template <typename ArchType>
 typename Configuration<ArchType>::PacketData
 Configuration<ArchType>::createType2ConfigurationPacketData(

--- a/lib/memory_mapped_file.cc
+++ b/lib/memory_mapped_file.cc
@@ -9,16 +9,56 @@
  */
 #include <prjxray/memory_mapped_file.h>
 
+#ifdef _WIN32
+#include <windows.h>
+#else
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#endif
 
 namespace prjxray {
 
 std::unique_ptr<MemoryMappedFile> MemoryMappedFile::InitWithFile(
     const std::string& path) {
+#ifdef _WIN32
+	HANDLE file = CreateFileA(path.c_str(), GENERIC_READ, FILE_SHARE_READ,
+	                          NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL,
+	                          NULL);
+	if (file == INVALID_HANDLE_VALUE)
+		return nullptr;
+
+	LARGE_INTEGER file_size;
+	if (!GetFileSizeEx(file, &file_size)) {
+		CloseHandle(file);
+		return nullptr;
+	}
+
+	// A zero-length file cannot be mapped; return an object (to indicate
+	// the file exists) with a nullptr and zero length.
+	if (file_size.QuadPart == 0) {
+		CloseHandle(file);
+		return std::unique_ptr<MemoryMappedFile>(
+		    new MemoryMappedFile(nullptr, 0));
+	}
+
+	HANDLE mapping =
+	    CreateFileMappingA(file, NULL, PAGE_READONLY, 0, 0, NULL);
+	// The view keeps the file/mapping alive, so the handles can be closed.
+	CloseHandle(file);
+	if (mapping == NULL)
+		return nullptr;
+
+	void* file_map = MapViewOfFile(mapping, FILE_MAP_READ, 0, 0, 0);
+	CloseHandle(mapping);
+	if (file_map == NULL)
+		return nullptr;
+
+	return std::unique_ptr<MemoryMappedFile>(new MemoryMappedFile(
+	    file_map, static_cast<size_t>(file_size.QuadPart)));
+#else
 	int fd = open(path.c_str(), O_RDONLY, 0);
 	if (fd == -1)
 		return nullptr;
@@ -51,10 +91,16 @@ std::unique_ptr<MemoryMappedFile> MemoryMappedFile::InitWithFile(
 
 	return std::unique_ptr<MemoryMappedFile>(
 	    new MemoryMappedFile(file_map, statbuf.st_size));
+#endif
 }
 
 MemoryMappedFile::~MemoryMappedFile() {
+#ifdef _WIN32
+	if (data_)
+		UnmapViewOfFile(data_);
+#else
 	munmap(data_, size_);
+#endif
 }
 
 }  // namespace prjxray

--- a/prjxray/util.py
+++ b/prjxray/util.py
@@ -8,7 +8,12 @@
 # https://opensource.org/licenses/ISC
 #
 # SPDX-License-Identifier: ISC
-import fcntl
+try:
+    import fcntl
+except ImportError:
+    # Windows: no fcntl (and no SIGALRM); OpenSafeFile degrades to a plain
+    # open without inter-process locking.
+    fcntl = None
 import math
 import os
 import random
@@ -47,6 +52,8 @@ class OpenSafeFile:
 
     def lock_file(self):
         assert self.fd is not None
+        if fcntl is None:
+            return
         try:
             signal.signal(signal.SIGALRM, timeout_handler)
             signal.alarm(self.timeout)
@@ -58,6 +65,8 @@ class OpenSafeFile:
 
     def unlock_file(self):
         assert self.fd is not None
+        if fcntl is None:
+            return
         fcntl.flock(self.fd.fileno(), fcntl.LOCK_UN)
 
 

--- a/utils/bit2fasm.py
+++ b/utils/bit2fasm.py
@@ -108,7 +108,12 @@ def main():
         if args.bits_file:
             bits_file = stack.enter_context(open(args.bits_file, 'wb'))
         else:
-            bits_file = stack.enter_context(tempfile.NamedTemporaryFile())
+            # On Windows an open NamedTemporaryFile cannot be re-opened by
+            # the bitread subprocess (sharing violation): create it closed
+            # and clean it up ourselves.
+            bits_file = tempfile.NamedTemporaryFile(delete=False)
+            bits_file.close()
+            stack.callback(os.unlink, bits_file.name)
 
         bit_to_bits(
             bitread=args.bitread,

--- a/utils/fasm2frames.py
+++ b/utils/fasm2frames.py
@@ -296,16 +296,16 @@ def main():
     parser.add_argument('fn_in', help='Input FPGA assembly (.fasm) file')
     parser.add_argument(
         'fn_out',
-        default='/dev/stdout',
+        default=None,
         nargs='?',
-        help='Output FPGA frame (.frm) file')
+        help='Output FPGA frame (.frm) file (default: stdout)')
 
     args = parser.parse_args()
     run(
         db_root=args.db_root,
         part=args.part,
         filename_in=args.fn_in,
-        f_out=open(args.fn_out, 'w'),
+        f_out=(open(args.fn_out, 'w') if args.fn_out else sys.stdout),
         sparse=args.sparse,
         roi=args.roi,
         debug=args.debug,


### PR DESCRIPTION
This batch makes the prjxray tools (`xc7frames2bit`, `bitread`, `xc7patch`) and
  the python utilities build and run natively on Windows. I have been shipping
  these as patches in the [apio `openxc7` package](https://github.com/FPGAwars/tools-openxc7) (for the momento only in the release bundle , and in next days i'm shipping the code + workflows to build all automatically for linux, osx and windows, our community is testing this days under Icestudio with good results).

This is  cross-compiled with mingw-w64, validated end-to-end under wine and on real
  Windows via apio.

contributing them back. Each commit is independent,  happy to split if you prefer.

  ## C++ library (Win32 ports, `#ifdef _WIN32`, POSIX paths untouched)

  - **lib: Win32 port of MemoryMappedFile**,  `open/fstat/mmap` →
    `CreateFileA/CreateFileMappingA/MapViewOfFile`. One behavioural note: a
    zero-length file cannot be mapped on Windows, so that case returns an object
    with null data and zero size to preserve the "file exists" contract of
    `InitWithFile`.
  - **lib: Win32 port of the Database segbits enumeration**, `glob(3)` →
    `FindFirstFileA/FindNextFileA`.
  
  ## ODR fix (this is a correctness bug on every platform)
  
  - **xilinx: declare the Configuration explicit specializations in
    configuration.h** , `configuration.cc` explicitly specializes
    `createType2ConfigurationPacketData<Spartan6>` and
    `createConfigurationPackage` (Spartan6/Series7/UltraScale/UltraScalePlus),
    but the specializations were never declared in the header. The standard
    requires the declaration to be visible in every TU that uses them
    ([temp.expl.spec]); without it, tool TUs instantiate the header-defined
    primary template and emit their own COMDAT copy, which collides with the
    strong definition from `configuration.cc` when linking `xc7frames2bit` /
    `xc7patch` with mingw-w64 ld ("multiple definition of ..."). ELF linkers
    happen to resolve the collision silently in favour of the strong symbol,
    which is why Linux builds never noticed. With the declarations in place the
    tools link WITHOUT `-Wl,--allow-multiple-definition`; no behaviour change on
    ELF.

  ## Python utilities

  - **util: make OpenSafeFile work without fcntl** , `prjxray/util.py` imported
    `fcntl` at module level, so merely importing `prjxray` failed on Windows.
    The only user is the advisory `flock` (whose timeout also relies on
    `SIGALRM`, equally POSIX-only): guard the import and skip locking when
    unavailable. POSIX behaviour unchanged.
  - **fasm2frames: default to sys.stdout instead of '/dev/stdout'**,  the
    literal path does not exist on Windows.
  - **bit2fasm: close the temporary bits file before bitread writes it** ,  an
    open `NamedTemporaryFile` cannot be re-opened by the `bitread` subprocess on
    Windows (sharing violation); create it with `delete=False`, close it, and
    unlink via the `ExitStack`.

  ## Validation

  Shipped in the apio `openxc7` windows-amd64 package (2026-07-31 release),
  cross-compiled with mingw-w64 and validated end-to-end under wine on
  xc7a35t/xc7a100t/xc7a200t: synth → nextpnr-xilinx → `fasm2frames` (run with the
  *Windows* python, which is what caught the POSIX-isms) → `xc7frames2bit`
  producing structurally valid bitstreams. The ODR fix is exercised by that same
  build linking without the workaround linker flag.

