### PR TITLE
039a-hclk-bufrclk-perfclk: fuzz the HCLK enable buffers of a consumed BUFR, and the CMT performance-clock path

### DIFF
--- a/fuzzers/039a-hclk-bufrclk-perfclk/Makefile
+++ b/fuzzers/039a-hclk-bufrclk-perfclk/Makefile
@@ -1,0 +1,95 @@
+# Copyright (C) 2017-2020  The Project X-Ray Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+
+# N randomised specimens plus the four one-hot calibration specimens and
+# the four negative controls.  See README.md for what each one is for.
+N ?= 50
+FUZDIR ?= ${PWD}
+
+RAND := $(addprefix build/specimen_,$(shell seq -f '%03.0f' $(N)))
+FIXED := \
+	build/specimen_cal0 \
+	build/specimen_cal1 \
+	build/specimen_cal2 \
+	build/specimen_cal3 \
+	build/specimen_neg_ioi \
+	build/specimen_neg_unused \
+	build/specimen_neg_bufh \
+	build/specimen_neg_unconsumed
+SPECIMENS := $(RAND) $(FIXED)
+SPECIMENS_OK := $(addsuffix /OK,$(SPECIMENS))
+
+all: database
+
+$(SPECIMENS_OK):
+	mkdir -p build
+	+bash $(FUZDIR)/generate.sh $(subst /OK,,$@)
+
+# The enable buffers are one bit, like the rest of the HCLK enables that
+# 039 and 058 resolve at -c 5.  The CMT performance-clock mux positions
+# are one or two bits and need the lower threshold 045 uses.  Neither
+# number is lowered to make a family resolve.
+SEGMATCH_EN = ${XRAY_SEGMATCH} -c 5
+SEGMATCH_PIP = ${XRAY_SEGMATCH} -c 2
+
+TILES := hclk_l hclk_r hclk_cmt hclk_cmt_l cmt_top_r_lower_b cmt_top_l_lower_b
+
+database: $(addprefix build/segbits_,$(addsuffix .db,$(TILES)))
+
+build/segbits_hclk_l.rdb: $(SPECIMENS_OK)
+	$(SEGMATCH_EN) -o $@ $(addsuffix /segdata_hclk_l.txt,$(SPECIMENS))
+
+build/segbits_hclk_r.rdb: $(SPECIMENS_OK)
+	$(SEGMATCH_EN) -o $@ $(addsuffix /segdata_hclk_r.txt,$(SPECIMENS))
+
+build/segbits_hclk_cmt.rdb: $(SPECIMENS_OK)
+	$(SEGMATCH_PIP) -o $@ $(addsuffix /segdata_hclk_cmt.txt,$(SPECIMENS))
+
+build/segbits_hclk_cmt_l.rdb: $(SPECIMENS_OK)
+	$(SEGMATCH_PIP) -o $@ $(addsuffix /segdata_hclk_cmt_l.txt,$(SPECIMENS))
+
+build/segbits_cmt_top_r_lower_b.rdb: $(SPECIMENS_OK)
+	$(SEGMATCH_PIP) -o $@ $(addsuffix /segdata_cmt_top_r_lower_b.txt,$(SPECIMENS))
+
+build/segbits_cmt_top_l_lower_b.rdb: $(SPECIMENS_OK)
+	$(SEGMATCH_PIP) -o $@ $(addsuffix /segdata_cmt_top_l_lower_b.txt,$(SPECIMENS))
+
+# filter_rdb.py splits the raw segmatch output into rows that carry bits,
+# pseudo-pips for routed pips with zero candidate bits, and a notes file
+# for everything it refuses to publish.
+build/segbits_%.db: build/segbits_%.rdb
+	python3 $(FUZDIR)/filter_rdb.py $< $@ build/ppips_$*.db build/$*.notes.txt
+
+# The calibration gate: if the one-hot specimens do not put 00_31 on
+# BUFRCLK2, the campaign resolved something else and nothing is merged.
+gate: build/segbits_hclk_l.db
+	grep -E 'ENABLE_BUFFER\.HCLK_CK_BUFRCLK2( [^ ]+)* 00_31( |$$)' $<
+
+# Only the rows that carry bits are merged.  The pseudo-pips land in
+# build/ppips_*.db already tile-prefixed; they are reviewed and applied
+# to ppips_cmt_top_{r,l}_lower_b.db by hand, the way the I2IOCLK default
+# positions were.  This fuzzer runs no maskmerge: its population is far
+# too narrow to rewrite a mask that 045 and 058 built.
+pushdb: gate
+	${XRAY_MERGEDB} hclk_l build/segbits_hclk_l.db
+	${XRAY_MERGEDB} hclk_r build/segbits_hclk_r.db
+	${XRAY_MERGEDB} hclk_cmt build/segbits_hclk_cmt.db
+	${XRAY_MERGEDB} hclk_cmt_l build/segbits_hclk_cmt_l.db
+	${XRAY_MERGEDB} cmt_top_r_lower_b build/segbits_cmt_top_r_lower_b.db
+	${XRAY_MERGEDB} cmt_top_l_lower_b build/segbits_cmt_top_l_lower_b.db
+
+run:
+	$(MAKE) clean
+	$(MAKE) database
+	$(MAKE) pushdb
+	touch run.ok
+
+clean:
+	rm -rf build run.ok
+
+.PHONY: all database gate pushdb run clean

--- a/fuzzers/039a-hclk-bufrclk-perfclk/README.md
+++ b/fuzzers/039a-hclk-bufrclk-perfclk/README.md
@@ -1,0 +1,106 @@
+# 039a-hclk-bufrclk-perfclk
+
+Fuzzer for the HCLK enable buffers of the four regional-clock spokes,
+and for the CMT performance-clock path that can feed them.
+
+039 walks the same HCLK_IOI3 tiles, but its BUFRs drive nothing. A BUFR
+whose output goes nowhere leaves the HCLK enable at zero, so four rows
+of `segbits_hclk_l.db` were never resolvable from that population:
+
+```
+HCLK_L.ENABLE_BUFFER.HCLK_CK_BUFRCLK0
+HCLK_L.ENABLE_BUFFER.HCLK_CK_BUFRCLK1
+HCLK_L.ENABLE_BUFFER.HCLK_CK_BUFRCLK2
+HCLK_L.ENABLE_BUFFER.HCLK_CK_BUFRCLK3
+```
+
+Here every BUFR that is IN_USE clocks a counter on two SLICEs of its own
+clock region, so the regional clock crosses the spine into the fabric.
+Part of the population is fed from the region's MMCM instead of from a
+clock-capable pad, which is what exercises `CLK_PERF` in
+`CMT_TOP_{R,L}_LOWER_B` and `HCLK_CMT_MUX_PHSR_PERFCLK` in
+`HCLK_CMT`/`HCLK_CMT_L`.
+
+Families: `hclk_l`, `hclk_r`, `hclk_cmt`, `hclk_cmt_l`,
+`cmt_top_r_lower_b`, `cmt_top_l_lower_b`.
+
+## Phase 0: what the tag is allowed to mean
+
+Two negative specimens are built and read **before** the tagging rule is
+written down, because the whole campaign depends on the answer.
+
+`neg_unconsumed` places a BUFR and leaves its `O` open: six
+`BUFR_Y0.IN_USE`, zero `HCLK_CK_BUFRCLKn->>HCLK_LEAF_CLK_B_*` pips, zero
+bits in the four candidate positions. Vivado does not set the enable for
+a BUFR that is merely placed.
+
+`neg_ioi` consumes the same BUFR in an ODDR of the IOI column: six
+`IN_USE`, six `HCLK_IOI_RCLK2IO2`, six `HCLK_CMT_CK_BUFRCLK2_USED`, and
+still zero leaf pips and zero bits. A clock consumed inside the IOI
+column never crosses the spine.
+
+So the predicate is the routed leaf pip in that tile, not the BUFR site
+and not `IN_USE` — 039's predicate would have tagged both negatives as
+ones. Pad-ODDR specimens stay in the randomised population as honest
+zeroes rather than being filtered out.
+
+## Specimens
+
+`make` builds `N` (default 50) randomised specimens plus eight fixed
+ones:
+
+| Specimen | Shape |
+|---|---|
+| `cal0` … `cal3` | one-hot: only that BUFRCLK index, pad-fed, on every HCLK_IOI3 |
+| `neg_unconsumed` | BUFR placed, `O` open |
+| `neg_ioi` | BUFR consumed by an ODDR in the IOI column |
+| `neg_unused` | no BUFR |
+| `neg_bufh` | BUFHCE into a CLB, no BUFR |
+
+The one-hot specimens are the calibration: each leaves exactly one
+unknown bit local to HCLK_L, which is what assigns a bit to an index
+rather than to the family. `make gate` fails the run if `BUFRCLK2` does
+not come back as `00_31`; nothing is merged when the gate fails.
+
+Two further modes, `perf0` and `perf1`, drive a single MMCM `CLKOUT`
+each. They are not part of `make database`: they exist to answer whether
+Vivado can be pushed onto a `CLK_PERF0` position, and on xc7a100t it
+cannot — it routes `CLKOUTn -> CLK_PERF3 -> MUXED3 -> PERFCLK3` whatever
+output is asked for.
+
+## Thresholds
+
+`-c 5` for the one-bit enables, as 039 and 058 use for the rest of the
+HCLK enables; `-c 2` for the CMT mux positions, as 045 uses. Neither is
+lowered to make a family resolve.
+
+## What the fuzzer refuses to publish
+
+`filter_rdb.py` splits the raw segmatch output three ways and writes a
+`.notes.txt` for everything it drops, so a refusal is visible rather
+than silent:
+
+- `<const0>` tags, never routed in this population, are reported and
+  dropped. On xc7a100t all four HCLK_R enables are const0.
+- A candidate bit that already belongs to a row of the database is
+  stripped by name: `05_21` on `BUFRCLK3` is
+  `HCLK_L.HCLK_LEAF_CLK_B_BOTL5.HCLK_CK_BUFRCLK3`, and `29_937` on
+  `CLK_PERF3.CLKOUT1` is
+  `MMCME2_ADV.CLKOUT1_CLKOUT1_OUTPUT_ENABLE[0]`. A correlation with an
+  existing row is not a new row. `CLK_PERF3.CLKOUT1` has nothing left
+  after the strip and is dropped entirely.
+- A pip the specimens do route for which segmatch finds zero candidate
+  bits is written to `build/ppips_*.db` as a `default` pseudo-pip, tile
+  prefix included. `mergedb` has no pseudo-pip mode, so those are
+  reviewed and applied to the database by hand.
+
+`make pushdb` merges only the rows that carry bits. The fuzzer runs no
+`maskmerge`: its population is far too narrow to rewrite masks that 045
+and 058 built from theirs.
+
+## Context
+
+Rows: the companion `prjxray-db` PR. Threads:
+`openXC7/nextpnr-xilinx#149` (the enables, and the review record for the
+phase-0 rule and the calibration gate) and `openXC7/nextpnr-xilinx#172`
+(the performance-clock path).

--- a/fuzzers/039a-hclk-bufrclk-perfclk/filter_rdb.py
+++ b/fuzzers/039a-hclk-bufrclk-perfclk/filter_rdb.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017-2020  The Project X-Ray Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+"""Split a raw segmatch .rdb into what may be published and what may not.
+
+Three outputs, so that nothing silently reaches the database:
+
+  segbits  rows that resolved to real bits.
+  ppips    pips the specimens do route and for which segmatch found zero
+           candidate bits, written as `default` pseudo-pips (the
+           all-zero mux position, the convention INT_L.BYP_ALT* uses).
+           The tag is rewritten to the tile type taken from the output
+           file name, because mergedb has no pseudo-pip mode and these
+           are applied to the database by hand after review.
+  notes    every line that was refused, and why.
+
+Two candidate bits are stripped by name because they belong to rows this
+database already carries, and a correlation with an existing row is not a
+new row:
+
+  05_21   HCLK_L.HCLK_LEAF_CLK_B_BOTL5.HCLK_CK_BUFRCLK3
+  29_937  CMT_TOP_*_LOWER_B.MMCME2_ADV.CLKOUT1_CLKOUT1_OUTPUT_ENABLE[0]
+
+A `<const0>` tag was never 1 in the population: it is reported, never
+published.  A row left with no bits after stripping is dropped too.
+"""
+
+import os
+import re
+import sys
+
+BIT_RE = re.compile(r"!?[0-9]+_[0-9]+$")
+
+# Bits that already belong to a row of the seed database, per tag suffix.
+KNOWN_COLLISIONS = (
+    ("ENABLE_BUFFER.HCLK_CK_BUFRCLK3", "05_21"),
+    ("CLK_PERF3", "29_937"),
+)
+
+
+def tile_prefix_from(ppips_path):
+    """ppips_cmt_top_r_lower_b.db -> CMT_TOP_R_LOWER_B."""
+    base = os.path.basename(ppips_path)
+    assert base.startswith("ppips_") and base.endswith(".db"), base
+    return base[len("ppips_"):-len(".db")].upper() + "."
+
+
+def collisions_for(tag):
+    out = set()
+    for needle, bit in KNOWN_COLLISIONS:
+        if needle in tag:
+            out.add(bit)
+    return out
+
+
+def main():
+    fn_in, fn_segbits, fn_ppips, fn_notes = sys.argv[1:5]
+    prefix = tile_prefix_from(fn_ppips)
+
+    segbits, ppips, notes = [], [], []
+    with open(fn_in) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            tag, rest = line.split(None, 1) if " " in line else (line, "")
+
+            drop = collisions_for(tag)
+            if drop:
+                bits = rest.split()
+                kept = [b for b in bits if b not in drop]
+                gone = [b for b in bits if b in drop]
+                if gone:
+                    notes.append(
+                        "stripped {} from {} -> {}".format(
+                            " ".join(gone), tag, " ".join(kept) or "(empty)"))
+                rest = " ".join(kept)
+
+            if rest.startswith("<const0>"):
+                notes.append("drop, never routed in the population: " + tag)
+                continue
+            if rest.startswith("<0 candidates>"):
+                ppips.append(
+                    "{} default".format(prefix + tag.split(".", 1)[1]))
+                notes.append("routed with zero candidate bits: " + tag)
+                continue
+            if rest.startswith("<"):
+                notes.append("drop, unresolved {}: {}".format(rest, tag))
+                continue
+            if not rest:
+                notes.append("drop, no bit left: " + tag)
+                continue
+            if not all(BIT_RE.match(b) for b in rest.split()):
+                notes.append("drop, not a bit list: " + line)
+                continue
+            segbits.append("{} {}".format(tag, rest))
+
+    for path, lines in ((fn_segbits, segbits), (fn_ppips, ppips),
+                        (fn_notes, notes)):
+        with open(path, "w") as f:
+            for l in lines:
+                f.write(l + "\n")
+
+    print(
+        "{}: segbits={} ppips={} refused={}".format(
+            os.path.basename(fn_in), len(segbits), len(ppips), len(notes)),
+        file=sys.stderr)
+    for n in notes:
+        print("  " + n, file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/fuzzers/039a-hclk-bufrclk-perfclk/generate.py
+++ b/fuzzers/039a-hclk-bufrclk-perfclk/generate.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017-2020  The Project X-Ray Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+#
+# Segmaker.  The HCLK_L / HCLK_R enable-buffer tag is read from the leaf
+# pip routed in THAT tile in THAT specimen,
+#
+#   HCLK_L_*/HCLK_L.HCLK_CK_BUFRCLKn->>HCLK_LEAF_CLK_B_*
+#
+# and never from the BUFR site or from BUFR_Yn.IN_USE, which is 039's
+# predicate.  Two negative specimens (see README) establish that a BUFR
+# which is placed, or consumed inside the IOI column, leaves the enable
+# at zero: what sets it is the clock crossing the spine into the fabric.
+# Specimens whose BUFR feeds an ODDR stay in the population as honest
+# zeroes rather than being excluded.
+#
+# The PERFCLK and CLK_PERF tags are read from the same pip dump.  045
+# skips the PHSR family through its EXCLUDE_RE, so those positions have
+# to be tagged explicitly.
+import os
+import re
+import sys
+
+from prjxray.db import Database
+from prjxray.segmaker import Segmaker
+from prjxray import util
+
+
+HCLK_CMT_PERFCLK = [
+    ("HCLK_CMT_MUX_PHSR_PERFCLK0", "HCLK_CMT_MUX_MMCM_MUXED0"),
+    ("HCLK_CMT_MUX_PHSR_PERFCLK1", "HCLK_CMT_MUX_MMCM_MUXED0"),
+    ("HCLK_CMT_MUX_PHSR_PERFCLK0", "HCLK_CMT_MUX_MMCM_MUXED1"),
+    ("HCLK_CMT_MUX_PHSR_PERFCLK1", "HCLK_CMT_MUX_MMCM_MUXED1"),
+    ("HCLK_CMT_MUX_PHSR_PERFCLK2", "HCLK_CMT_MUX_MMCM_MUXED2"),
+    ("HCLK_CMT_MUX_PHSR_PERFCLK3", "HCLK_CMT_MUX_MMCM_MUXED2"),
+    ("HCLK_CMT_MUX_PHSR_PERFCLK2", "HCLK_CMT_MUX_MMCM_MUXED3"),
+    ("HCLK_CMT_MUX_PHSR_PERFCLK3", "HCLK_CMT_MUX_MMCM_MUXED3"),
+]
+
+CMT_CLKOUTS = [
+    "CMT_LR_LOWER_B_MMCM_CLKFBOUT",
+    "CMT_LR_LOWER_B_MMCM_CLKOUT0",
+    "CMT_LR_LOWER_B_MMCM_CLKOUT1",
+    "CMT_LR_LOWER_B_MMCM_CLKOUT2",
+    "CMT_LR_LOWER_B_MMCM_CLKOUT3",
+]
+
+LEAF_DST_PREFIX = "HCLK_LEAF_CLK_B_"
+
+
+def parse_pips(path):
+    """Return {tile: set((src, dst))} from generate.tcl's design_pips.txt."""
+    used = {}
+    if not os.path.exists(path):
+        return used
+    rx = re.compile(r"^([^/]+)/[^.]+(?:\.)(.+?)->>?(.+)$")
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            m = rx.match(line)
+            if not m:
+                continue
+            tile, src, dst = m.group(1), m.group(2), m.group(3)
+            used.setdefault(tile, set()).add((src, dst))
+    return used
+
+
+def cmt_perf_pairs(side):
+    dests = ["CMT_{}_LOWER_B_CLK_PERF{}".format(side, n) for n in range(4)]
+    return [(d, s) for s in CMT_CLKOUTS for d in dests]
+
+
+def leaf_pip_present(tile_used, n):
+    """True iff this tile routed HCLK_CK_BUFRCLKn onto a leaf clock."""
+    src_want = "HCLK_CK_BUFRCLK{}".format(n)
+    for src, dst in tile_used:
+        routed_to_leaf = (
+            src == src_want and dst.startswith(LEAF_DST_PREFIX)
+        )
+        if routed_to_leaf:
+            return True
+    return False
+
+
+def main():
+    segmk = Segmaker("design.bits")
+    used = parse_pips("design_pips.txt")
+
+    db = Database(util.get_db_root(), util.get_part())
+    grid = db.grid()
+
+    n_en_one = 0
+    n_en_tiles = 0
+    for tile_name in grid.tiles():
+        loc = grid.loc_of_tilename(tile_name)
+        gi = grid.gridinfo_at_loc(loc)
+        ttype = gi.tile_type
+        tile_used = used.get(tile_name, set())
+
+        if ttype in ("HCLK_L", "HCLK_R"):
+            any_one = False
+            for n in range(4):
+                tag = "ENABLE_BUFFER.HCLK_CK_BUFRCLK{}".format(n)
+                val = 1 if leaf_pip_present(tile_used, n) else 0
+                segmk.add_tile_tag(tile_name, tag, val)
+                n_en_one += val
+                any_one = any_one or bool(val)
+            n_en_tiles += int(any_one)
+
+        elif ttype in ("HCLK_CMT", "HCLK_CMT_L"):
+            for dst, src in HCLK_CMT_PERFCLK:
+                tag = "{}.{}".format(dst, src)
+                val = 1 if (src, dst) in tile_used else 0
+                segmk.add_tile_tag(tile_name, tag, val)
+
+        elif ttype == "CMT_TOP_R_LOWER_B":
+            for dst, src in cmt_perf_pairs("R"):
+                tag = "{}.{}".format(dst, src)
+                val = 1 if (src, dst) in tile_used else 0
+                segmk.add_tile_tag(tile_name, tag, val)
+
+        elif ttype == "CMT_TOP_L_LOWER_B":
+            for dst, src in cmt_perf_pairs("L"):
+                tag = "{}.{}".format(dst, src)
+                val = 1 if (src, dst) in tile_used else 0
+                segmk.add_tile_tag(tile_name, tag, val)
+
+    print("tiles_with_pips={} enable_ones={} enable_tiles={}".format(
+        len(used), n_en_one, n_en_tiles), file=sys.stderr)
+
+    def bitfilter(frame, bit):
+        return True
+
+    segmk.compile(bitfilter=bitfilter)
+    segmk.write(allow_empty=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/fuzzers/039a-hclk-bufrclk-perfclk/generate.sh
+++ b/fuzzers/039a-hclk-bufrclk-perfclk/generate.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Copyright (C) 2017-2020  The Project X-Ray Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+#
+# Specimen driver: derive FUZZ_MODE from the specimen directory name and
+# hand over to the generic top_generate.mk.
+set -euo pipefail
+
+spec="${1:?specimen dir}"
+
+# A directory left behind by an interrupted run would be picked up as
+# finished work.  Drop only this specimen, never a sibling.
+if [ -d "$spec" ] && [ ! -f "$spec/OK" ]; then
+    rm -rf "$spec"
+fi
+
+# genheader.sh reads $SPECDIR before exporting it, which is fine without
+# nounset and aborts with it.  Its own scripts run under `set -ex` only.
+set +u
+# shellcheck disable=SC1090
+source "${XRAY_GENHEADER}"
+set -u
+
+case "$(basename "$SPECDIR")" in
+    specimen_cal0) export FUZZ_MODE=cal0 ;;
+    specimen_cal1) export FUZZ_MODE=cal1 ;;
+    specimen_cal2) export FUZZ_MODE=cal2 ;;
+    specimen_cal3) export FUZZ_MODE=cal3 ;;
+    specimen_neg_ioi) export FUZZ_MODE=neg_ioi ;;
+    specimen_neg_unused) export FUZZ_MODE=neg_unused ;;
+    specimen_neg_bufh) export FUZZ_MODE=neg_bufh ;;
+    specimen_neg_unconsumed) export FUZZ_MODE=neg_unconsumed ;;
+    specimen_perf0) export FUZZ_MODE=perf0 ;;
+    specimen_perf1) export FUZZ_MODE=perf1 ;;
+    *) export FUZZ_MODE="${FUZZ_MODE:-campaign}" ;;
+esac
+
+make -f "${XRAY_DIR}/utils/top_generate.mk"

--- a/fuzzers/039a-hclk-bufrclk-perfclk/generate.tcl
+++ b/fuzzers/039a-hclk-bufrclk-perfclk/generate.tcl
@@ -1,0 +1,54 @@
+# Copyright (C) 2017-2020  The Project X-Ray Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+#
+# 039's bitstream path plus a dump of the used pips of the HCLK and CMT
+# tiles the rows live on.  The tags are read from those pips, not from
+# the placed primitives, so the dump is part of the measurement.
+proc dump_used_clock_pips {filename} {
+    set fp [open $filename w]
+    set nets [get_nets -quiet -hierarchical]
+    foreach net $nets {
+        foreach pip [get_pips -quiet -of_objects $net] {
+            if {[regexp {HCLK_L_|HCLK_R_|HCLK_CMT|CMT_TOP_.*LOWER_B} $pip]} {
+                puts $fp "$pip"
+            }
+        }
+    }
+    close $fp
+}
+
+proc dump_sites {filename filter} {
+    set fp [open $filename w]
+    foreach c [get_cells -quiet -hierarchical -filter $filter] {
+        puts $fp "[get_property NAME $c] [get_sites -quiet -of_objects $c]"
+    }
+    close $fp
+}
+
+proc run {} {
+    create_project -force -part $::env(XRAY_PART) design design
+    read_verilog top.v
+    synth_design -top top
+
+    set_property CFGBVS VCCO [current_design]
+    set_property CONFIG_VOLTAGE 3.3 [current_design]
+    set_property BITSTREAM.GENERAL.PERFRAMECRC YES [current_design]
+
+    place_design
+    route_design
+
+    dump_sites bufr_sites.txt {REF_NAME == BUFR}
+    dump_sites bufh_sites.txt {REF_NAME == BUFHCE}
+    dump_sites mmcm_sites.txt {REF_NAME =~ MMCME2*}
+    dump_used_clock_pips design_pips.txt
+
+    write_checkpoint -force design.dcp
+    write_bitstream -force design.bit
+}
+
+run

--- a/fuzzers/039a-hclk-bufrclk-perfclk/top.py
+++ b/fuzzers/039a-hclk-bufrclk-perfclk/top.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017-2020  The Project X-Ray Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+#
+# Specimen generator.  Walks the HCLK_IOI3 tiles the way 039 does, but
+# every BUFR that is IN_USE is actually consumed: its output clocks a
+# counter on two SLICEs of the same clock region, so the regional clock
+# has to cross the HCLK spine into the fabric.  That is what turns the
+# HCLK_L enable buffers on.  A share of the BUFRs are fed from the
+# region's MMCM instead of from a clock-capable pad, which is what
+# exercises the CMT performance-clock path.
+#
+# FUZZ_MODE:
+#   campaign (default)  random mix of unused / pad_clb / mmcm_clb / pad_oddr
+#   cal0..cal3          one-hot: only that BUFRCLK index, pad-fed, every tile
+#   neg_ioi             cal2 shape but the BUFR is consumed by an IOI ODDR
+#   neg_unused          no BUFR at all
+#   neg_bufh            BUFHCE into a CLB, no BUFR
+#   neg_unconsumed      BUFR placed with its O left open
+#   perf0 / perf1       MMCM CLKOUT0 only / CLKOUT1 only, CLB sink
+import json
+import os
+import random
+import sys
+
+from prjxray.db import Database
+from prjxray import util
+
+REL_Y_TO_BUFRCLK = {0: 2, 1: 3, 2: 0, 3: 1}
+BUFRCLK_TO_REL_Y = {v: k for k, v in REL_Y_TO_BUFRCLK.items()}
+
+IOSTANDARD = os.getenv("XRAY_IOSTANDARD", "LVCMOS33")
+MODE = os.getenv("FUZZ_MODE", "campaign")
+
+
+def seed_rng():
+    raw = os.getenv("SEED", "0")
+    try:
+        random.seed(int(raw, 16))
+    except ValueError:
+        random.seed(int(os.getenv("SEEDN", "1")))
+
+
+def load_grid():
+    db = Database(util.get_db_root(), util.get_part())
+    return db.grid()
+
+
+def mmcm_by_region(grid):
+    out = {}
+    for tn in grid.tiles():
+        gi = grid.gridinfo_at_loc(grid.loc_of_tilename(tn))
+        for st, sty in gi.sites.items():
+            if sty == "MMCME2_ADV" and gi.clock_region is not None:
+                out[str(gi.clock_region)] = (tn, st)
+    return out
+
+
+def slices_by_region(grid):
+    out = {}
+    for tn in grid.tiles():
+        gi = grid.gridinfo_at_loc(grid.loc_of_tilename(tn))
+        if gi.clock_region is None:
+            continue
+        if gi.tile_type not in ("CLBLL_L", "CLBLL_R", "CLBLM_L", "CLBLM_R"):
+            continue
+        cr = str(gi.clock_region)
+        for st, sty in gi.sites.items():
+            if sty in ("SLICEL", "SLICEM"):
+                out.setdefault(cr, []).append(st)
+    for cr in out:
+        out[cr].sort()
+    return out
+
+
+def gen_hclk_ioi3(grid):
+    """Yield (tile, x_min, y_min, bufr_sites, iob33m, iob33s, region, mmcm_site)."""
+    xy_bufr = util.create_xy_fun("BUFR_")
+    mmcm = mmcm_by_region(grid)
+    for tile_name in sorted(grid.tiles()):
+        loc = grid.loc_of_tilename(tile_name)
+        gi = grid.gridinfo_at_loc(loc)
+        sites = []
+        for site, site_type in gi.sites.items():
+            if site_type == "BUFR":
+                x, y = xy_bufr(site)
+                sites.append((site, x, y))
+        if not sites:
+            continue
+        ioi3 = grid.gridinfo_at_loc((loc.grid_x, loc.grid_y - 1))
+        if "IOI3" not in ioi3.tile_type:
+            continue
+        if ioi3.tile_type.startswith("R"):
+            dx = 1
+        else:
+            dx = -1
+        iobs_m, iobs_s = [], []
+        for dy in (-1, -3, 2, 4):
+            iob = grid.gridinfo_at_loc((loc.grid_x + dx, loc.grid_y + dy))
+            for site, site_type in iob.sites.items():
+                if site_type == "IOB33M":
+                    iobs_m.append(site)
+                elif site_type == "IOB33S":
+                    iobs_s.append(site)
+        region = str(gi.clock_region) if gi.clock_region is not None else ""
+        mmcm_site = mmcm.get(region, (None, None))[1]
+        xs = [s[1] for s in sites]
+        ys = [s[2] for s in sites]
+        yield (
+            tile_name,
+            min(xs),
+            min(ys),
+            sorted(sites, key=lambda t: t[2]),
+            sorted(iobs_m),
+            sorted(iobs_s),
+            region,
+            mmcm_site,
+        )
+
+
+def choose_state(rel_y):
+    if MODE == "campaign":
+        return random.choice(
+            ["unused", "unused", "pad_clb", "pad_clb", "pad_clb",
+             "mmcm_clb", "mmcm_clb", "pad_oddr"])
+    if MODE in ("cal0", "cal1", "cal2", "cal3"):
+        want = int(MODE[-1])
+        return "pad_clb" if REL_Y_TO_BUFRCLK[rel_y] == want else "unused"
+    if MODE == "neg_ioi":
+        return "pad_oddr" if rel_y == 0 else "unused"
+    if MODE == "neg_unused":
+        return "unused"
+    if MODE == "neg_bufh":
+        return "unused"
+    if MODE == "neg_unconsumed":
+        return "pad_open" if rel_y == 0 else "unused"
+    if MODE in ("perf0", "perf1"):
+        return "mmcm_clb" if rel_y == 0 else "unused"
+    raise SystemExit("unknown FUZZ_MODE={}".format(MODE))
+
+
+def ibuf_block(site, idx, ioclk):
+    return """
+    wire {ioclk};
+    (* KEEP, DONT_TOUCH, LOC="{site}" *)
+    IBUF #(.IOSTANDARD("{iost}")) ibuf_{idx} (
+        .I(clks[{idx}]),
+        .O({ioclk})
+    );
+""".format(ioclk=ioclk, site=site, idx=idx, iost=IOSTANDARD)
+
+
+def mmcm_block(name, clkin, site):
+    return """
+    wire {n}_fb, {n}_out0, {n}_out1, {n}_out2, {n}_out3;
+    (* KEEP, DONT_TOUCH, LOC="{site}" *)
+    MMCME2_BASE #(
+        .CLKIN1_PERIOD(10.0), .CLKFBOUT_MULT_F(8.0), .DIVCLK_DIVIDE(1),
+        .CLKOUT0_DIVIDE_F(8.0), .CLKOUT1_DIVIDE(8),
+        .CLKOUT2_DIVIDE(8), .CLKOUT3_DIVIDE(8)
+    ) {n} (
+        .CLKIN1({clkin}), .CLKFBIN({n}_fb), .CLKFBOUT({n}_fb),
+        .CLKOUT0({n}_out0), .CLKOUT1({n}_out1),
+        .CLKOUT2({n}_out2), .CLKOUT3({n}_out3),
+        .RST(1'b0), .PWRDWN(1'b0)
+    );
+""".format(n=name, clkin=clkin, site=site)
+
+
+def bufr_block(site, src, consume, oddr_site=None, out_idx=0):
+    head = """
+    wire {site}_o;
+    (* KEEP, DONT_TOUCH, LOC="{site}" *)
+    BUFR #(.BUFR_DIVIDE("BYPASS")) buf_{site} (
+        .CE(1'b1), .CLR(1'b0), .I({src}), .O({site}_o)
+    );
+""".format(site=site, src=src)
+    if consume == "clb":
+        return head  # flops added by the caller from the wire
+    if consume == "oddr" and oddr_site is not None:
+        return head + """
+    wire {site}_q;
+    (* KEEP, DONT_TOUCH *)
+    ODDR #(.DDR_CLK_EDGE("SAME_EDGE")) oddr_{site} (
+        .C({site}_o), .CE(1'b1), .D1(1'b1), .D2(1'b0),
+        .R(1'b0), .S(1'b0), .Q({site}_q)
+    );
+    (* KEEP, DONT_TOUCH, LOC="{obuf}" *)
+    OBUF #(.IOSTANDARD("LVCMOS33")) obuf_{site} (.I({site}_q), .O(outs[{idx}]));
+""".format(site=site, obuf=oddr_site, idx=out_idx)
+    # unconsumed: still drive O so the primitive exists, but no sink
+    return """
+    (* KEEP, DONT_TOUCH, LOC="{site}" *)
+    BUFR #(.BUFR_DIVIDE("BYPASS")) buf_{site} (
+        .CE(1'b1), .CLR(1'b0), .I({src})
+    );
+""".format(site=site, src=src)
+
+
+def counter_block(clk, slices, tag):
+    """8 FDRE on two SLICEs, clocked by clk."""
+    if len(slices) < 2:
+        return ""
+    s0, s1 = slices[0], slices[1]
+    lines = ["    wire [7:0] q_{t};".format(t=tag)]
+    d_expr = [
+        "~q_{t}[0]".format(t=tag),
+        "q_{t}[1] ^ q_{t}[0]".format(t=tag),
+        "q_{t}[2] ^ (q_{t}[1] & q_{t}[0])".format(t=tag),
+        "q_{t}[3] ^ (q_{t}[2] & q_{t}[1] & q_{t}[0])".format(t=tag),
+        "q_{t}[4] ^ (q_{t}[3] & q_{t}[2] & q_{t}[1] & q_{t}[0])".format(t=tag),
+        "q_{t}[5] ^ (q_{t}[4] & q_{t}[3] & q_{t}[2] & q_{t}[1] & q_{t}[0])".format(t=tag),
+        "q_{t}[6] ^ (q_{t}[5] & q_{t}[4] & q_{t}[3] & q_{t}[2] & q_{t}[1] & q_{t}[0])".format(t=tag),
+        "q_{t}[7] ^ (q_{t}[6] & q_{t}[5] & q_{t}[4] & q_{t}[3] & q_{t}[2] & q_{t}[1] & q_{t}[0])".format(t=tag),
+    ]
+    bels = ["AFF", "BFF", "CFF", "DFF"]
+    for i in range(8):
+        sl = s0 if i < 4 else s1
+        bel = bels[i % 4]
+        lines.append("""
+    (* KEEP, DONT_TOUCH, LOC="{sl}", BEL="{bel}" *)
+    FDRE #(.INIT(1'b0)) ff_{t}_{i} (
+        .C({clk}), .CE(1'b1), .R(1'b0), .D({d}), .Q(q_{t}[{i}])
+    );""".format(sl=sl, bel=bel, t=tag, i=i, clk=clk, d=d_expr[i]))
+    return "\n".join(lines)
+
+
+def bufh_block(clkin, slice_site):
+    return """
+    wire bufh_o;
+    wire ff_bufh_q;
+    (* KEEP, DONT_TOUCH *)
+    BUFHCE bufh_i (.I({clkin}), .CE(1'b1), .O(bufh_o));
+    (* KEEP, DONT_TOUCH, LOC="{sl}", BEL="AFF" *)
+    FDRE #(.INIT(1'b0)) ff_bufh (
+        .C(bufh_o), .CE(1'b1), .R(1'b0), .D(~ff_bufh_q), .Q(ff_bufh_q)
+    );
+""".format(clkin=clkin, sl=slice_site)
+
+
+def main():
+    seed_rng()
+    grid = load_grid()
+    slices = slices_by_region(grid)
+
+    params = []
+    outputs = []
+    num_clocks = 0
+    num_outs = 0
+    slice_cursor = {cr: 0 for cr in slices}
+
+    def take_slices(cr, n=2):
+        pool = slices.get(cr, [])
+        i = slice_cursor.get(cr, 0)
+        got = pool[i:i + n]
+        slice_cursor[cr] = i + n
+        return got
+
+    tiles = list(gen_hclk_ioi3(grid))
+    if not tiles:
+        sys.stderr.write("no HCLK_IOI3 tiles\n")
+        sys.exit(1)
+
+    for tile, x_min, y_min, bufr_sites, iobs_m, iobs_s, region, mmcm_site in tiles:
+        ioclks = []
+        for iob in iobs_m:
+            ioclk = "clk_{}".format(iob.replace("/", "_"))
+            ioclks.append(ioclk)
+            outputs.append(ibuf_block(iob, num_clocks, ioclk))
+            num_clocks += 1
+        if not ioclks:
+            continue
+
+        mmcm_name = "mmcm_{}".format(tile.replace("/", "_"))
+        mmcm_declared = False
+        clkout_for_mode = 0 if MODE != "perf1" else 1
+
+        for site, x, y in bufr_sites:
+            rel_y = y - y_min
+            state = choose_state(rel_y)
+            rec = {
+                "tile": tile,
+                "site": site,
+                "rel_y": rel_y,
+                "bufrclk": REL_Y_TO_BUFRCLK.get(rel_y),
+                "region": region,
+                "state": state,
+                "IN_USE": 0 if state == "unused" else 1,
+            }
+            if state == "unused":
+                params.append(rec)
+                continue
+
+            src = ioclks[rel_y % len(ioclks)]
+            if state.startswith("mmcm"):
+                if mmcm_site is None:
+                    state = "pad_clb"
+                    rec["state"] = state
+                else:
+                    if not mmcm_declared:
+                        outputs.append(mmcm_block(mmcm_name, ioclks[0], mmcm_site))
+                        mmcm_declared = True
+                    if MODE in ("perf0", "perf1"):
+                        src = "{}_out{}".format(mmcm_name, clkout_for_mode)
+                    else:
+                        src = "{}_out{}".format(mmcm_name, rel_y % 4)
+                    rec["source"] = "mmcm"
+            else:
+                rec["source"] = "pad"
+
+            if state in ("pad_clb", "mmcm_clb"):
+                rec["sink"] = "clb"
+                outputs.append(bufr_block(site, src, "clb"))
+                sl = take_slices(region, 2)
+                outputs.append(counter_block("{}_o".format(site), sl, site.replace("/", "_")))
+            elif state == "pad_oddr":
+                rec["sink"] = "oddr"
+                if not iobs_s:
+                    sys.stderr.write(
+                        "no IOB33S for ODDR on {}, leaving O open\n"
+                        .format(tile))
+                    rec["sink"] = "open"
+                    rec["oddr_skipped"] = 1
+                    outputs.append(bufr_block(site, src, "open"))
+                else:
+                    ob = iobs_s[num_outs % len(iobs_s)]
+                    outputs.append(bufr_block(site, src, "oddr", ob, num_outs))
+                    num_outs += 1
+            elif state == "pad_open":
+                rec["sink"] = "open"
+                outputs.append(bufr_block(site, src, "open"))
+            params.append(rec)
+
+        if MODE == "neg_bufh" and tile == tiles[0][0]:
+            sl = take_slices(region, 1)
+            if sl:
+                outputs.append(bufh_block(ioclks[0], sl[0]))
+                params.append({
+                    "tile": tile,
+                    "kind": "BUFH",
+                    "region": region,
+                    "IN_USE": 1,
+                })
+
+    nclk = max(num_clocks - 1, 0)
+    nout = max(num_outs - 1, 0)
+    # Do not emit an undriven `outs` port: Vivado then tries to place it
+    # and IO placer dies (`Place 30-58`, 1 unplaced port, 0 pins).
+    # Hits every cal* / neg_unconsumed / neg_unused / neg_bufh specimen.
+    if num_outs == 0:
+        print("module top(input [{}:0] clks);".format(nclk))
+    else:
+        print("module top(input [{}:0] clks, output [{}:0] outs);".format(nclk, nout))
+    print("    (* KEEP, DONT_TOUCH *) LUT6 dummy ();")
+    for block in outputs:
+        print(block)
+    print("endmodule")
+
+    with open("params.json", "w") as f:
+        json.dump(params, f, indent=2)
+    sys.stderr.write("MODE={} clocks={} bufr_used={}\n".format(
+        MODE, num_clocks, sum(1 for p in params if p.get("IN_USE"))))
+
+
+if __name__ == "__main__":
+    main()

--- a/fuzzers/Makefile
+++ b/fuzzers/Makefile
@@ -213,6 +213,11 @@ $(eval $(call fuzzer,056-pip-rem,049-int-imux-gfan 050-pip-seed 051-pip-imuxlout
 $(eval $(call fuzzer,057-pip-bi,056-pip-rem,all))
 ifneq ($(QUICK),Y)
 $(eval $(call fuzzer,058-pip-hclk,005-tilegrid,all))
+# 039a needs the HCLK_IOI3 / IOB33 tiles of a high-range bank, and merges
+# into files 045 and 058 own, so it runs after both.
+ifeq ($(HAS_HIGH_RANGE_BANKS),1)
+$(eval $(call fuzzer,039a-hclk-bufrclk-perfclk,005-tilegrid 045-hclk-cmt-pips 058-pip-hclk,all))
+endif
 $(eval $(call fuzzer,059-pip-byp-bounce,048-int-piplist,all))
 $(eval $(call fuzzer,060-bram-cascades,005-tilegrid,all))
 $(eval $(call fuzzer,071-ppips,057-pip-bi 058-pip-hclk 060-bram-cascades,all))


### PR DESCRIPTION
The fuzzer that mints the rows in openXC7/prjxray-db#13.

`039-hclk-config` walks these same HCLK_IOI3 tiles, but its BUFRs drive nothing, and a BUFR whose output goes nowhere leaves the HCLK enable at zero. That is why four rows of `segbits_hclk_l.db` were never resolvable from that population — `ENABLE_BUFFER.HCLK_CK_BUFRCLK0..3`, the enable buffers of the four regional-clock spokes — while their four BUFHCLK siblings have been in the database since 058-pip-hclk, and so have all 48 `HCLK_LEAF_CLK_B_*` leaf pips that carry a BUFR clock onto a leaf clock.

**The specimen class.** Every BUFR that is IN_USE here is consumed: its output clocks an eight-bit counter on two SLICEs of its own clock region, so the regional clock has to cross the HCLK spine into the fabric. A share of the population is fed from the region's `MMCME2_ADV` rather than from a clock-capable pad, which is what exercises `CLK_PERF` in `CMT_TOP_{R,L}_LOWER_B` and `HCLK_CMT_MUX_PHSR_PERFCLK` in `HCLK_CMT`/`HCLK_CMT_L`. Families: `hclk_l`, `hclk_r`, `hclk_cmt`, `hclk_cmt_l`, `cmt_top_r_lower_b`, `cmt_top_l_lower_b`.

**Phase 0 — what the tag is allowed to mean.** Two negative specimens are built and read *before* `generate.py` is written, because the whole campaign depends on the answer:

- `neg_unconsumed`, a BUFR placed with its `O` open: 6 `BUFR_Y0.IN_USE`, **zero** `HCLK_CK_BUFRCLKn->>HCLK_LEAF_CLK_B_*` pips, **zero** bits in the four candidate positions. Vivado does not set the enable for a BUFR that is merely placed.
- `neg_ioi`, the same BUFR consumed by an ODDR in the IOI column: 6 `IN_USE`, 6 `HCLK_IOI_RCLK2IO2`, 6 `HCLK_CMT_CK_BUFRCLK2_USED`, and **still zero** leaf pips and zero bits. A clock consumed inside the IOI column never crosses the spine.

So the predicate is the routed leaf pip in that tile, not the BUFR site and not `IN_USE` — 039's predicate would have tagged both negatives as ones. Pad-ODDR specimens stay in the randomised population as honest zeroes rather than being filtered out, and `generate.tcl` dumps the used pips of the HCLK and CMT tiles because that dump is the measurement.

**Calibration.** Four one-hot specimens, `cal0`..`cal3`, each driving exactly one BUFRCLK index on every HCLK_IOI3 of the part. Each leaves exactly one unknown bit local to HCLK_L, which is what assigns a bit to an *index* rather than to the family. `make gate` fails the run if BUFRCLK2 does not come back as `00_31`, and `pushdb` depends on the gate, so a campaign that resolved something else merges nothing. Thresholds are 039/058's `-c 5` for the one-bit enables and 045's `-c 2` for the CMT mux positions; neither is lowered to make a family resolve.

**What it refuses to publish.** `filter_rdb.py` splits the raw segmatch output three ways and writes a notes file for every line it drops, so a refusal is visible rather than silent:

- `<const0>` tags were never routed in the population — on xc7a100t that is all four HCLK_R enables — and are reported, not published.
- A candidate bit that already belongs to a row of the database is stripped by name: `05_21` on BUFRCLK3 is `HCLK_L.HCLK_LEAF_CLK_B_BOTL5.HCLK_CK_BUFRCLK3`, `29_937` on `CLK_PERF3.CLKOUT1` is `MMCME2_ADV.CLKOUT1_CLKOUT1_OUTPUT_ENABLE[0]`. A correlation with an existing row is not a new row. `CLK_PERF3.CLKOUT1` has nothing left afterwards and is dropped whole.
- A pip the specimens do route for which segmatch finds zero candidate bits becomes a `default` pseudo-pip in `build/ppips_*.db`, tile prefix included, for review — `mergedb` has no pseudo-pip mode, so those are applied by hand the way the `I2IOCLK` positions were in openXC7/prjxray-db#7 — or withheld, as this campaign's CLK_PERF candidates of that class are (the database PR states why).

`pushdb` merges only the rows that carry bits. The fuzzer runs no `maskmerge`: its population is far too narrow to rewrite masks that 045 and 058 built from theirs.

**`perf0` / `perf1`** drive a single MMCM `CLKOUT` each and are not part of `make database`. They exist to answer whether Vivado can be pushed onto a `CLK_PERF0` position, and on xc7a100t it cannot: it routes `CLKOUTn -> CLK_PERF3 -> MUXED3 -> PERFCLK3` whatever output is asked for. That is why the two exact keys of openXC7/nextpnr-xilinx#172 are not minted by this campaign, and why no `route_via` appears anywhere in it.

**Registration**: `fuzzers/Makefile`, gated on `HAS_HIGH_RANGE_BANKS` (it needs HCLK_IOI3 and IOB33 sites) and ordered after 045-hclk-cmt-pips and 058-pip-hclk, whose files it merges into.

58 specimens on xc7a100tfgg676-1 seeded from openXC7/prjxray-db. Rows: openXC7/prjxray-db#13 . Context: openXC7/nextpnr-xilinx#149 and openXC7/nextpnr-xilinx#172. Co-designed with @gHashTag, who supplied the HCLK_R eight-hole layout the fill order was predicted from, the silicon A/B on index 2, and the bit-level round trip on `xc7a200tfbg484-2`.
