### PR TITLE
005-tilegrid: read the grid off a pristine device, and the spartan7 fixes the xc7s25 model needed

### DIFF
--- a/fuzzers/005-tilegrid/generate_full.py
+++ b/fuzzers/005-tilegrid/generate_full.py
@@ -534,6 +534,48 @@ def propagate_IOI_Y9(database, tiles_by_grid):
         database[tile]['bits']['CLB_IO_CLK']['offset'] = 18
 
 
+def propagate_CFG_CENTER_MID(database, tiles_by_grid, tile_frames_map):
+    """ Give CFG_CENTER_MID its base address when the cfg fuzzer could not.
+
+    The cfg sub-fuzzer solves this tile by sweeping BSCANE2's JTAG_CHAIN
+    between 1 and 2.  On spartan7 Vivado writes the JTAG_CHAIN_1 bit whichever
+    value the netlist asks for, so the tag never toggles, segmatch reports
+    "<0 candidates>" and the tile ends up with no bits at all: xc7s100 has
+    shipped that way since it was added, and utils/checkdb.py aborts on it with
+    "block type BlockType.CLB_IO_CLK is not present in current tile".
+
+    Nothing about the address is unknown, though.  CFG_CENTER_MID spans its
+    whole clock-region row -- offset 0, 101 words, as in every device model in
+    the database -- and its configuration column is measured by the cfg_int
+    fuzzer on the INT tiles of that same column.  Take it from there, and leave
+    a tile the cfg fuzzer did solve alone.
+    """
+    for tile_name in sorted(database.keys()):
+        tile = database[tile_name]
+        if tile['type'] != 'CFG_CENTER_MID' or tile['bits']:
+            continue
+        # walk right along the row to the interconnect column of this
+        # configuration column
+        grid_x = tile['grid_x']
+        while True:
+            grid_x += 1
+            neighbour = tiles_by_grid.get((grid_x, tile['grid_y']))
+            if neighbour is None:
+                break
+            ntile = database[neighbour]
+            if ntile['type'] not in ('INT_L', 'INT_R'):
+                continue
+            bits = ntile['bits'].get('CLB_IO_CLK')
+            if bits is None:
+                break
+            baseaddr = int(bits['baseaddr'], 0)
+            localutil.add_tile_bits(
+                tile_name, tile, baseaddr, 0,
+                tile_frames_map.get_tile_frames(baseaddr), 101,
+                tile_frames_map)
+            break
+
+
 def alias_HCLKs(database):
     """ Generate HCLK aliases for HCLK_[LR] subsets.
 
@@ -578,6 +620,7 @@ def run(json_in_fn, json_out_fn, verbose=False):
     propagate_IOB_SING(database, tiles_by_grid)
     propagate_IOI_SING(database, tiles_by_grid)
     propagate_IOI_Y9(database, tiles_by_grid)
+    propagate_CFG_CENTER_MID(database, tiles_by_grid, tile_frames_map)
     alias_HCLKs(database)
 
     # Save

--- a/fuzzers/005-tilegrid/generate_tiles.tcl
+++ b/fuzzers/005-tilegrid/generate_tiles.tcl
@@ -62,13 +62,27 @@ proc write_tiles_txt {} {
 }
 
 proc run {} {
-    # Generate grid of entire part
-    make_project_roi XRAY_ROI_TILEGRID XRAY_EXCLUDE_ROI_TILEGRID
+    # Read the grid off a device with NOTHING placed on it.  SITE_TYPE reports
+    # the type a site is currently configured as, so any cell placed first
+    # rewrites it: a BUFG cell turns a BUFGCTRL site into "BUFG", assigning a
+    # port to a package pin collapses IOB33M/IOB33S to "IOB33", and a RAMB36
+    # cell collapses RAMBFIFO36E1 to "RAMB36E1".  Those names go straight into
+    # tilegrid.json, and the sub-fuzzers of this same fuzzer then select their
+    # sites by site type, so the damage compounds: with BUFGCTRL_X0Y0..2 read
+    # as "BUFG", 005-tilegrid/clk_bufg silently measures BUFGCTRL_X0Y10 instead
+    # of X0Y0 and lands CLK_BUFG_BOT_R five words past its real base address.
+    # Nothing write_tiles_txt reads (TYPE, GRID_POINT_*, SITE_TYPE, PROHIBIT,
+    # CLOCK_REGION, PIN_FUNC) needs a design, so open the part and stop there.
+    create_project -force -part $::env(XRAY_PART) design design
+    link_design -part $::env(XRAY_PART)
 
-    place_design
-    route_design
-    write_checkpoint -force design.dcp
-    write_bitstream -force design.bit
+    # XRAY_EXCLUDE_ROI_TILEGRID names the tiles write_tiles_txt must replace
+    # with NULL; it reads them back through this pblock.
+    create_pblock exclude_roi
+    foreach roi "$::env(XRAY_EXCLUDE_ROI_TILEGRID)" {
+        puts "EXCLUDE ROI: $roi"
+        resize_pblock [get_pblocks exclude_roi] -add "$roi"
+    }
 
     write_tiles_txt
 }

--- a/settings/spartan7.sh
+++ b/settings/spartan7.sh
@@ -10,26 +10,59 @@ export XRAY_DATABASE="spartan7"
 export XRAY_PART="xc7s25csga324-1"
 export XRAY_ROI_FRAMES="0x00000000:0xffffffff"
 
-# All CLB's in part, all BRAM's in part, all DSP's in part.
-# tcl queries IOB => don't bother adding
-export XRAY_ROI_TILEGRID="SLICE_X0Y0:SLICE_X65Y99 SLICE_X0Y100:SLICE_X57Y149 RAMB18_X0Y0:RAMB18_X1Y59 RAMB36_X0Y0:RAMB36_X1Y29 RAMB18_X2Y0:RAMB18_X2Y39 RAMB36_X2Y0:RAMB36_X2Y19 DSP48_X0Y0:DSP48_X1Y59"
-
-export XRAY_EXCLUDE_ROI_TILEGRID=""
-
-# This is used by fuzzers/005-tilegrid/generate_full.py
-# (special handling for frame addresses of certain IOIs -- see the script for details).
-# This needs to be changed for any new device!
-# If you have a FASM mismatch or unknown bits in IOIs, CHECK THIS FIRST.
-export XRAY_IOI3_TILES="LIOI3_X0Y9 RIOI3_X43Y9"
-
-# These settings must remain in sync
-export XRAY_ROI="SLICE_X0Y100:SLICE_X35Y149 RAMB18_X0Y40:RAMB18_X0Y59 RAMB36_X0Y20:RAMB36_X0Y29 DSP48_X0Y40:DSP48_X0Y59 IOB_X0Y100:IOB_X0Y149"
-# Most of CMT X0Y2.
-export XRAY_ROI_GRID_X1="10"
-export XRAY_ROI_GRID_X2="58"
-# Include VBRK / VTERM
-export XRAY_ROI_GRID_Y1="0"
-export XRAY_ROI_GRID_Y2="51"
+# The fabric geometry below is per device, not per family: xc7s25 is a
+# different die from xc7s50, and xc7s75/xc7s100 are a third one.  Selecting it
+# from XRAY_PART keeps the default part (xc7s25csga324-1, the Arty S7-25)
+# runnable while leaving the other devices reachable with XRAY_PART=...
+case "${XRAY_PART}" in
+xc7s25*)
+    # xc7s25: SLICE X0..X41 over Y0..Y49 and X0..X33 over Y50..Y99 (the
+    # top-right clock region is narrower); 3 BRAM and 2 DSP columns.
+    export XRAY_ROI_TILEGRID="SLICE_X0Y0:SLICE_X41Y49 SLICE_X0Y50:SLICE_X33Y99 RAMB18_X0Y0:RAMB18_X1Y39 RAMB36_X0Y0:RAMB36_X1Y19 RAMB18_X2Y0:RAMB18_X2Y19 RAMB36_X2Y0:RAMB36_X2Y9 DSP48_X0Y0:DSP48_X1Y39"
+    export XRAY_EXCLUDE_ROI_TILEGRID=""
+    # See fuzzers/005-tilegrid/generate_full.py: the two IOI3 tiles whose frame
+    # address sits one frame above the rest of their column.
+    export XRAY_IOI3_TILES="LIOI3_X0Y9 RIOI3_X31Y9"
+    # Most of clock region X0Y1.
+    export XRAY_ROI="SLICE_X0Y50:SLICE_X15Y99 RAMB18_X0Y20:RAMB18_X0Y39 RAMB36_X0Y10:RAMB36_X0Y19 DSP48_X0Y20:DSP48_X0Y39 IOB_X0Y50:IOB_X0Y99"
+    export XRAY_ROI_GRID_X1="10"
+    export XRAY_ROI_GRID_X2="50"
+    export XRAY_ROI_GRID_Y1="0"
+    export XRAY_ROI_GRID_Y2="51"
+    ;;
+xc7s75*|xc7s100*)
+    # xc7s75 and xc7s100 are the same die: SLICE X0..X85 over Y0..Y199,
+    # 3 BRAM and 2 DSP columns spanning the full height.
+    export XRAY_ROI_TILEGRID="SLICE_X0Y0:SLICE_X85Y199 RAMB18_X0Y0:RAMB18_X2Y79 RAMB36_X0Y0:RAMB36_X2Y39 DSP48_X0Y0:DSP48_X1Y79"
+    export XRAY_EXCLUDE_ROI_TILEGRID=""
+    export XRAY_IOI3_TILES="LIOI3_X0Y9 RIOI3_X43Y9"
+    export XRAY_ROI="SLICE_X0Y150:SLICE_X35Y199 RAMB18_X0Y60:RAMB18_X0Y79 RAMB36_X0Y30:RAMB36_X0Y39 DSP48_X0Y60:DSP48_X0Y79 IOB_X0Y150:IOB_X0Y199"
+    export XRAY_ROI_GRID_X1="10"
+    export XRAY_ROI_GRID_X2="58"
+    export XRAY_ROI_GRID_Y1="0"
+    export XRAY_ROI_GRID_Y2="51"
+    ;;
+*)
+    # xc7s50 (and the xc7s6/xc7s15 proxies, which have no fabric of their own).
+    # All CLB's in part, all BRAM's in part, all DSP's in part.
+    # tcl queries IOB => don't bother adding
+    export XRAY_ROI_TILEGRID="SLICE_X0Y0:SLICE_X65Y99 SLICE_X0Y100:SLICE_X57Y149 RAMB18_X0Y0:RAMB18_X1Y59 RAMB36_X0Y0:RAMB36_X1Y29 RAMB18_X2Y0:RAMB18_X2Y39 RAMB36_X2Y0:RAMB36_X2Y19 DSP48_X0Y0:DSP48_X1Y59"
+    export XRAY_EXCLUDE_ROI_TILEGRID=""
+    # This is used by fuzzers/005-tilegrid/generate_full.py
+    # (special handling for frame addresses of certain IOIs -- see the script for details).
+    # This needs to be changed for any new device!
+    # If you have a FASM mismatch or unknown bits in IOIs, CHECK THIS FIRST.
+    export XRAY_IOI3_TILES="LIOI3_X0Y9 RIOI3_X43Y9"
+    # These settings must remain in sync
+    export XRAY_ROI="SLICE_X0Y100:SLICE_X35Y149 RAMB18_X0Y40:RAMB18_X0Y59 RAMB36_X0Y20:RAMB36_X0Y29 DSP48_X0Y40:DSP48_X0Y59 IOB_X0Y100:IOB_X0Y149"
+    # Most of CMT X0Y2.
+    export XRAY_ROI_GRID_X1="10"
+    export XRAY_ROI_GRID_X2="58"
+    # Include VBRK / VTERM
+    export XRAY_ROI_GRID_Y1="0"
+    export XRAY_ROI_GRID_Y2="51"
+    ;;
+esac
 
 # clock pin
 export XRAY_PIN_00="F14"

--- a/settings/spartan7/devices.yaml
+++ b/settings/spartan7/devices.yaml
@@ -1,14 +1,18 @@
 # device to fabric mapping
-"xc7s50":
-  fabric: "xc7s50"
 "xc7s25":
   fabric: "xc7s25"
-"xc7s6":
-  fabric: "xc7s25"
-"xc7s15":
-  fabric: "xc7s25"
-
+"xc7s50":
+  fabric: "xc7s50"
+# xc7s75 and xc7s100 are the same die: Vivado reports the identical 28633
+# tiles and 28793 sites for xc7s75fgga676-1 and xc7s100fgga676-1, and their
+# part.yaml frame layouts are identical (9104 frames, 54 columns per row).
 "xc7s75":
   fabric: "xc7s100"
 "xc7s100":
   fabric: "xc7s100"
+# xc7s6 and xc7s15 are a fourth, smaller die (1324 frames, 35 columns against
+# xc7s25's 3060 and 75) and have no fabric of their own yet.  They are left
+# unmapped on purpose: an unmapped part fails loudly, while pointing them at
+# another device's fabric silently addresses the wrong frames -- the failure
+# mode that made every xc7s25 bitstream wrong until this device got its own
+# model.

--- a/utils/environment.sh
+++ b/utils/environment.sh
@@ -24,6 +24,13 @@ if [ -e "${XRAY_DIR}/env/bin/activate" ]; then
 fi
 
 # misc
+# The I/O standard the fuzzers drive their ROI pins with.  Only virtex7 needs a
+# different one (its HP banks are 1.8 V) and settings/virtex7.sh sets it before
+# sourcing this file; every other family runs the high-range default, which is
+# the same fallback the python fuzzers already use (fuzzers/039-hclk-config,
+# fuzzers/039a-hclk-bufrclk-perfclk).  Without it the tcl fuzzers abort with
+# "no such variable ::env(XRAY_IOSTANDARD)".
+export XRAY_IOSTANDARD="${XRAY_IOSTANDARD:-LVCMOS33}"
 export XRAY_PART_YAML="${XRAY_DATABASE_DIR}/${XRAY_DATABASE}/${XRAY_PART}/part.yaml"
 source $XRAY_UTILS_DIR/environment.python.sh
 
@@ -46,11 +53,13 @@ export XRAY_PARSEDB="python3 ${XRAY_UTILS_DIR}/parsedb.py"
 export XRAY_TCL_REFORMAT="${XRAY_UTILS_DIR}/tcl-reformat.sh"
 export XRAY_VIVADO="${XRAY_UTILS_DIR}/vivado.sh"
 
-# Verify an approved version is in use
+# Verify an approved version is in use.  XRAY_VIVADO_VERSION lets a lab select
+# a different release without editing this file; the database is generated from
+# whatever Vivado reports here, so it is worth stating explicitly.
 export XRAY_VIVADO_SETTINGS="${XRAY_VIVADO_SETTINGS:-/tools/Xilinx/Vivado/2024.1/settings64.sh}"
-# Vivado v2017.2 (64-bit)
-if [ "$(${XRAY_VIVADO} -h |grep Vivado |cut -d\  -f 2)" != "v2024.1" ] ; then
-    echo "Requires Vivado 2017.2. See https://github.com/SymbiFlow/prjxray/issues/14"
+export XRAY_VIVADO_VERSION="${XRAY_VIVADO_VERSION:-v2024.1}"
+if [ "$(${XRAY_VIVADO} -h |grep Vivado |cut -d\  -f 2)" != "${XRAY_VIVADO_VERSION}" ] ; then
+    echo "Requires Vivado ${XRAY_VIVADO_VERSION#v}; set XRAY_VIVADO_VERSION to use another."
     # Can't exit since sourced script
     # Trash a key environment variable to preclude use
     export XRAY_DIR="/bad/vivado/version"


### PR DESCRIPTION
# prjxray: 005-tilegrid reads the grid off a placed design, and spartan7 has one fabric per device

This is the tool half of a pair; the database half is
openXC7/prjxray-db#15, which carries the `xc7s25` device model this branch
produces. Nothing here is spartan7-only except the settings file: the first
two commits fix bugs that affect every family.

## 1. `005-tilegrid` was reading site types off a *placed* design

`generate_tiles.tcl` built the ROI design, placed it, routed it, wrote a
bitstream and only then called `write_tiles_txt`. But `SITE_TYPE` reports the
type a site is *currently configured as*, so every site the design touched came
back renamed:

| site | pristine | after the ROI design is placed |
|---|---|---|
| `BUFGCTRL_X0Y0..2` | `BUFGCTRL` | `BUFG` |
| the IOBs `assign_iobs` uses | `IOB33M` / `IOB33S` | `IOB33` |
| `RAMB36_X0Y3..10` | `RAMBFIFO36E1` | `RAMB36E1` |

Those names go straight into `tilegrid.json`. Worse, the sub-fuzzers of this
same fuzzer pick their sites *by site type* out of that file, so the damage
compounds. Concretely, on `xc7s25csga324-1`:

* `clk_bufg/top.py` keeps the sites whose type is exactly `BUFGCTRL`. With
  `X0Y0`, `X0Y1` and `X0Y2` read as `BUFG` they were dropped, and
  `sorted(...)[0]` became `BUFGCTRL_X0Y10`.
* `X0Y10`'s `INIT_OUT` bit is five words further up the tile than `X0Y0`'s, so
  the fuzzer solved `CLK_BUFG_BOT_R` at word 98 instead of 93 — and
  `add_tdb.py` writes `words: 8` for `clk_bufg`, which makes `offset + words`
  102 and trips its own `offset + words <= 101` assertion.
* `iob/top.py` keeps `IOB33S` sites, so every IOB tile whose site had been
  collapsed to `IOB33` was skipped.

The already-published `spartan7/xc7s100` model shows the same fingerprint:
`CLK_BUFG_BOT_R_X73Y100` is recorded there as `offset 98, words 3`, while the
other thirteen device models in the database — three artix7, five kintex7, five
zynq7, virtex7 and xc7s50 — all say `offset 93, words 8`, and `CLK_BUFG_TOP_R`
is `offset 0, words 8` everywhere including xc7s100. `xc7s100`'s tilegrid also
carries eight `BRAM_L` tiles typed `RAMB36E1` while its other 112 say
`RAMBFIFO36E1`, and one `CLK_BUFG_BOT_R` whose `BUFGCTRL_X0Y0..2` are typed
`BUFG`.

Nothing `write_tiles_txt` reads (`TYPE`, `GRID_POINT_*`, `SITE_TYPE`,
`PROHIBIT`, `CLOCK_REGION`, `PIN_FUNC`) needs a design at all, so the fix is to
open the part, create the `exclude_roi` pblock the dump needs, and stop there.
The step also gets much cheaper: 36 s to 8 s on this part.

Measured after the fix, on `xc7s25csga324-1`:

* `clk_bufg` LOCs `BUFGCTRL_X0Y0` and solves `CLK_BUFG_BOT_R` at word **93**,
  matching every other device model in the database.
* the site types come out `IOB33: 6, IOB33S: 72, IOB33M: 72` and
  `RAMBFIFO36E1: 45`, and the dump is byte-identical to an independent
  `link_design`-only dump of the same part (10710 tiles, zero differing
  fields).

## 2. `XRAY_IOSTANDARD` was only set for virtex7

`fuzzers/005-tilegrid/util.tcl` and the sub-fuzzers' `generate.tcl` read
`$::env(XRAY_IOSTANDARD)` unconditionally, but only `settings/virtex7.sh` sets
it, so on artix7, kintex7, spartan7 and zynq7 the fuzzer aborts with

```
no such variable
    (read trace on "::env(XRAY_IOSTANDARD)")
```

`utils/environment.sh` now defaults it to `LVCMOS33` — the same fallback the
python fuzzers already use (`fuzzers/039-hclk-config/top.py`,
`fuzzers/039a-hclk-bufrclk-perfclk/top.py`) — and virtex7 keeps its `LVCMOS18`
because `settings/virtex7.sh` sets the variable before sourcing environment.sh.

## 3. `CFG_CENTER_MID` never gets an address on spartan7

The `cfg` sub-fuzzer solves that tile by sweeping `BSCANE2`'s `JTAG_CHAIN`
between 1 and 2. On this device Vivado 2026.1 writes the `JTAG_CHAIN_1` bit
whichever value the netlist asks for — the two specimens' `design.bits` are
identical, ten bits each — so the tag never toggles, `segmatch` returns
`<0 candidates>` and the tile ends up with no `bits` entry at all. That is why
`utils/checkdb.py` aborts today on `xc7s100fgga676-1` with

```
AssertionError: block type BlockType.CLB_IO_CLK is not present in current tile
```

Nothing about the address is actually unknown: `CFG_CENTER_MID` spans its whole
clock-region row (`offset 0`, `words 101`, as in every device model in the
database), and its configuration column *is* measured — by `cfg_int` on the INT
tiles of that same column, and by `monitor` on the other half of the die.
`generate_full.py` now takes the base address from the interconnect column, the
same way `propagate_rebuf` and `propagate_IOB_SING` already fill in tiles no
sub-fuzzer measures directly. On xc7s25 the result is
`0x00400900 / 30 frames / offset 0 / 101 words`, the bottom-half twin of the
measured `MONITOR_BOT_FUJI2` entry `0x00000900`, and `checkdb` passes.

I did not touch the `cfg` fuzzer's `JTAG_CHAIN` sweep — someone with a spartan7
board may want to work out whether Vivado is ignoring the parameter or the DRC
override is dropping it.

## 4. spartan7 has three dies, not one

`settings/spartan7.sh` carried one `XRAY_ROI_TILEGRID` while the default part
had already moved to `xc7s25csga324-1`. The ROI it declared
(`SLICE_X0Y100:SLICE_X35Y149`) is entirely outside that device, whose fabric
stops at `SLICE_X41Y49` / `SLICE_X33Y99`. The geometry is now selected from
`XRAY_PART`:

* **xc7s25** — `SLICE X0..X41` over `Y0..Y49` and `X0..X33` over `Y50..Y99`
  (the top-right clock region is narrower), 3 BRAM and 2 DSP columns,
  `XRAY_IOI3_TILES="LIOI3_X0Y9 RIOI3_X31Y9"`.
* **xc7s75 / xc7s100** — `SLICE X0..X85` over `Y0..Y199`,
  `XRAY_IOI3_TILES="LIOI3_X0Y9 RIOI3_X43Y9"`.
* **xc7s50** — unchanged.

Every number comes from Vivado's own site list for the part, not from a guess.

`settings/spartan7/devices.yaml` gains `xc7s75 -> xc7s100` (Vivado reports the
identical 28633 tiles and 28793 sites for `xc7s75fgga676-1` and
`xc7s100fgga676-1`, and their `part.yaml` frame layouts are identical: 9104
frames, 54 columns per row) and drops the `xc7s6`/`xc7s15 -> xc7s25` lines.
Those two are a fourth, smaller die — 1324 frames and 35 columns against
xc7s25's 3060 and 75 — and pointing them at another device's fabric is exactly
the failure this pair of pull requests exists to fix: an unmapped part fails
loudly, a wrongly mapped one silently addresses the wrong frames.

## 5. `XRAY_VIVADO_VERSION`

`utils/environment.sh` hard-codes the accepted Vivado release. It now honours
`XRAY_VIVADO_VERSION` (default `v2024.1`, unchanged), so a lab on another
release can run the fuzzers without editing a tracked file. The database this
branch produced was generated with Vivado 2026.1.

## How this was run

`fuzzers/005-tilegrid` end to end on `xc7s25csga324-1`, Vivado 2026.1, all 21
spartan7 sub-fuzzers green. Credit where it is due: the spartan7 side of this
fuzzer is @AssassinK786's work (openXC7/prjxray#12, openXC7/prjxray-db#11/#12),
and the xc7s100 run is the template this one followed.
