### PR TITLE
Xc7s100 tilegrid fuzzer fixes

### DIFF
--- a/settings/spartan7_xc7s100.sh
+++ b/settings/spartan7_xc7s100.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Copyright (C) 2017-2021  The Project X-Ray Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+export XRAY_DATABASE="spartan7"
+export XRAY_PART="xc7s100fgga676-1"
+export XRAY_ROI_FRAMES="0x00000000:0xffffffff"
+
+# All CLB's in part, all BRAM's in part, all DSP's in part.
+# tcl queries IOB => don't bother adding
+export XRAY_ROI_TILEGRID="SLICE_X0Y0:SLICE_X65Y99 SLICE_X0Y100:SLICE_X57Y149 RAMB18_X0Y0:RAMB18_X1Y59 RAMB36_X0Y0:RAMB36_X1Y29 RAMB18_X2Y0:RAMB18_X2Y39 RAMB36_X2Y0:RAMB36_X2Y19 DSP48_X0Y0:DSP48_X1Y59"
+
+export XRAY_EXCLUDE_ROI_TILEGRID=""
+
+# This is used by fuzzers/005-tilegrid/generate_full.py
+# (special handling for frame addresses of certain IOIs -- see the script for details).
+# This needs to be changed for any new device!
+# If you have a FASM mismatch or unknown bits in IOIs, CHECK THIS FIRST.
+export XRAY_IOI3_TILES="LIOI3_X0Y9 RIOI3_X53Y9"
+
+# These settings must remain in sync
+export XRAY_ROI="SLICE_X0Y100:SLICE_X35Y149 RAMB18_X0Y40:RAMB18_X0Y59 RAMB36_X0Y20:RAMB36_X0Y29 DSP48_X0Y40:DSP48_X0Y59 IOB_X0Y100:IOB_X0Y149"
+# Most of CMT X0Y2.
+export XRAY_ROI_GRID_X1="10"
+export XRAY_ROI_GRID_X2="58"
+# Include VBRK / VTERM
+export XRAY_ROI_GRID_Y1="0"
+export XRAY_ROI_GRID_Y2="51"
+
+# clock pin
+export XRAY_PIN_00="F14"
+# data pins
+export XRAY_PIN_01="F13"
+export XRAY_PIN_02="E13"
+export XRAY_PIN_03="H15"
+export XRAY_PIN_04="G15"
+export XRAY_PIN_05="K16"
+export XRAY_PIN_06="J16"
+
+source $(dirname ${BASH_SOURCE[0]:-$0})/../utils/environment.sh
+
+eval $(python3 ${XRAY_UTILS_DIR}/create_environment.py)
+ENV_RET=$?
+if [[ $ENV_RET != 0 ]] ; then
+	return $ENV_RET
+fi
+eval $env


### PR DESCRIPTION
## Summary

Now that `openXC7/prjxray-db#15` and `openXC7/prjxray#16` are merged, this PR is trimmed to just the settings file: `settings/spartan7_xc7s100.sh`, a per-part environment for `xc7s100fgga676-1`, following the existing per-part settings convention (`XRAY_ROI_TILEGRID` covering the part's full CLB/BRAM/DSP extent, `XRAY_IOI3_TILES` for the two IOI3 columns this device needs for `005-tilegrid`'s special IOI frame-address handling, pin assignments for a small ROI probe design).

## What was dropped, and why

The original revision also carried two defensive changes to `fuzzers/005-tilegrid/util.py` (a `global_clock_regions`-missing sentinel, and an `offset + words` clamp near the 101-word frame boundary). Per review: both conditions are ones #15/#16 remove at the root, not permanent states to work around:

- `part.json` without `global_clock_regions` was true for every spartan7 part before #15 (commit `fa75af7`) regenerated complete `part.json` files for all 57 of them. With that in, the max-frames cross-check should just run.
- The frame-boundary overflow on `CLK_BUFG_BOT_R` turned out to be the exact fingerprint of the SITE_TYPE-off-a-placed-design bug #16 fixes (`BUFGCTRL_X0Y0..2` misread as `BUFG`, landing the `clk_bufg` sub-fuzzer 5 words off). Clamping it would silence the one assertion that catches that bug recurring.

Both were correctly caught as work-arounds that would become unnecessary, and in the second case actively counterproductive, once the root fixes landed -- so this revision drops that part of the diff entirely rather than keep it as now-dead defensive code.

## Next step

Re-running `005-tilegrid` on `xc7s100fgga676-1` on the now-pristine grid, to regenerate the fingerprinted xc7s100 model (the 98/93 offset bug, the `RAMB36E1`/`RAMBFIFO36E1` mismatch, the `BUFGCTRL`-typed-as-`BUFG` sites, and the `CFG_CENTER_MID` gap that fails `checkdb` on it today) -- taking this up as a separate follow-up PR against `prjxray-db`, using this settings file.
