### PR TITLE
utils: derive a device tilegrid from its grid, and the calibration gate that keeps it honest

### DIFF
--- a/docs/db_dev_process/tilegrid_derivation.rst
+++ b/docs/db_dev_process/tilegrid_derivation.rst
@@ -1,0 +1,174 @@
+Deriving a tilegrid, and the gate that keeps it honest
+======================================================
+
+``utils/tilegrid_derive.py`` builds a device ``tilegrid.json`` out of a Vivado
+grid dump and the device models the database already holds, without running
+``005-tilegrid`` and without a bitstream.  It exists to be a *second opinion*:
+run the fuzzer, derive the same device, compare.  Where the two agree the
+model has been measured twice by methods that share nothing; where they
+disagree, one of them is wrong and the comparison says which tile to look at.
+
+It is also how a model built for the wrong device shows itself.  The committed
+``xc7s25`` and ``xc7s75`` models were the ``xc7s50`` fabric for years; what
+caught them was this tool refusing to derive them, because their grid declares
+44 interconnect columns where their own ``part.yaml`` declares 38 and 54.
+
+The law
+-------
+
+Every frame address in a tilegrid has the same shape::
+
+    baseaddr = (block_type << 23) | (bottom << 22) | (row << 17) | (column << 7)
+
+column
+    The rank of the tile's own configuration column, counted left to right
+    over the grid columns that carry an interconnect tile (``INT_L``,
+    ``INT_R``, ``INT_FEEDTHRU_2``) for the ``CLB_IO_CLK`` bus, or a block-RAM
+    tile (``BRAM_L``, ``BRAM_R``) for the ``BLOCK_RAM`` bus.  Which of those
+    columns a tile belongs to is a fixed per-tile-type grid_x delta: a
+    ``CLBLL_L`` sits one column left of its ``INT_L``, a ``DSP_R`` two columns
+    right of its ``INT_R``.
+
+    Note the feed-through columns.  Where the configuration centre interrupts
+    the fabric, ``INT_FEEDTHRU_2`` sits exactly where the interconnect would;
+    the column still exists in the bitstream and still consumes a column
+    index.  That is why ``xc7s25`` declares 38 configuration columns in its
+    bottom half but has only 32 interconnect columns.
+
+bottom, row
+    The clock-region row the tile lives in, numbered outward from the middle
+    of the device.  Which rows exist in each half comes from ``part.yaml``.
+
+offset, words, frames
+    A fixed function of the tile type and of the tile's vertical position
+    inside its clock-region row.  ``frames`` is capped by the column's own
+    ``frame_count``, exactly as ``fuzzers/005-tilegrid/util.py`` caps it.
+
+The per-tile-type deltas and geometries are not written down anywhere in the
+tool: they are learned from the device models in the database, which is to say
+from bitstreams that ``005-tilegrid`` measured on real silicon.  The law is
+learned per family, because tile geometry does differ between families.
+
+The gate
+--------
+
+A law that cannot rebuild the models we already trust has no business building
+one we cannot check, so::
+
+    utils/tilegrid_derive.py calibrate --database-dir database
+
+leaves one device model out at a time, learns the law from the rest of its
+family, rebuilds it from its grid alone and diffs it against the committed
+file.  It needs no Vivado.  Against openXC7/prjxray-db at the merge of #15,
+**11 of the 17 device models come out byte for byte identical, 500405
+``bits`` entries in all**:
+
+======== =============================================== ===============
+family   device models reproduced exactly                bits entries
+======== =============================================== ===============
+artix7   xc7a100t, xc7a50t                                        29834
+kintex7  xc7k70t, xc7k160t, xc7k325t, xc7k420t, xc7k480t          287790
+spartan7 xc7s50                                                   10342
+zynq7    xc7z030, xc7z045, xc7z100                                172439
+======== =============================================== ===============
+
+The remaining six are accounted for, and the same command prints why:
+
+``xc7vx485t`` (skipped)
+    The only virtex7 device model there is; nothing to learn the law from.
+
+``xc7z010`` (refused)
+    Its PS7 swallows 24 configuration columns down the left-hand side, so the
+    column rule does not hold on it at all: 38 interconnect columns in the
+    grid against 56 in ``part.yaml``.  The tool refuses the device rather than
+    deriving nonsense, and refuses to learn from it too.
+
+``xc7a200t`` (220 entries missing)
+    The only artix7 device with GTP transceivers in the middle of the die.  No
+    other artix7 model carries ``GTP_*_MID_*``, so the law has nothing to
+    learn their geometry from and leaves them unaddressed.
+
+``xc7z020`` (159 entries missing)
+    The only zynq7 device model with a right-hand high-range I/O column, now
+    that ``xc7z010`` is refused.  Every reference it has puts that kind of
+    tile on the *left*, so the tool cannot tell which side of ``RIOB33`` its
+    interconnect column is on -- and does not guess.
+
+``xc7s25`` (7 entries differ)
+    Six upper ``*_SING`` tiles differ in ``alias.start_offset`` alone, where
+    the derivation says 0 and the fuzzed model says 2.  This is a real
+    inconsistency in the database, not in the law: ``generate_full.py`` has
+    written 2 since the VC707 fix, and every model committed before ``xc7s25``
+    still says 0.  The seventh is ``MONITOR_BOT_FUJI2``, a XADC variant no
+    other spartan7 device has.
+
+``xc7s100`` (7 entries differ)
+    This one is worth reading as a result rather than a limitation: the model
+    was fuzzed before prjxray#16, so it carries the fingerprint of the
+    site-type-off-a-placed-design bug.  ``CLK_BUFG_BOT_R`` sits at offset 98
+    where the derivation and thirteen other device models say 93,
+    ``CFG_CENTER_MID`` has no address at all, and five ``LIOB33`` tiles have
+    none either -- the five whose sites read back as plain ``IOB33`` because
+    the ROI design had bound them.
+
+``utils/test_tilegrid_derive.py`` runs the same calibration as a test, with
+that table written down: any device model that starts differing in a *new* way
+fails it.  It skips when there is no database to calibrate against, since the
+repository itself carries only the mapping files.
+
+Where the references disagree
+-----------------------------
+
+Two reference models can contradict each other -- that is what a wrong model
+looks like from the inside.  The tool resolves a disagreement by counting
+devices: the majority of the family wins; if the family is split evenly, the
+models of the *other* families break the tie; if nothing breaks it, the first
+``--reference`` given wins and the conflict is reported as ``arbitrary``,
+which ``derive`` refuses to proceed on unless told to.  Whichever way it goes,
+the disagreement is printed with the vote::
+
+    CLK_BUFG_BOT_R row_position=47 CLB_IO_CLK -- resolved by other families
+        {"frames": 30, "offset": 93, "words": 8} xc7s50 (+13 elsewhere)
+        {"frames": 30, "offset": 98, "words": 3} xc7s100
+
+Adding a device
+---------------
+
+The tool never invents.  A tile type no reference model of the family carries
+gets no address at all, and ``derive`` says so at the end of its run.  With
+``--cross-family-fallback`` it will borrow such a geometry from the other
+families and count those entries separately; that is worth having for a new
+device (on ``xc7z020`` it fills the whole right-hand I/O column correctly, 156
+entries), and worth being careful with (it also addresses hard blocks such as
+``GTP_*`` and ``PCIE_*`` that the committed models deliberately leave alone).
+
+The flow for a device the database does not have yet, alongside
+:doc:`newpart`::
+
+    # 1. the grid, straight out of Vivado.  No ROI design, no settings file:
+    #    005-tilegrid reads the grid off a device with nothing placed on it,
+    #    and this runs that same tcl on its own.
+    source settings/<family>.sh
+    utils/dump_grid.sh <part> work/<part>
+
+    # 2. the derived model, and what it could not address
+    utils/tilegrid_derive.py derive --db-root database/<family> --part <part> \
+        --tiles work/<part>/tiles.txt --pin-func work/<part>/pin_func.txt \
+        --output work/<part>/derived.json
+
+    # 3. the fuzzer, which is still what the database ships
+    make -j$(nproc) db-part-only-<new_device>
+
+    # 4. the two against each other
+    utils/tilegrid_derive.py compare database/<family>/<device>/tilegrid.json \
+        work/<part>/derived.json --labels fuzzed derived
+
+Step 4 is the point of the exercise.  ``compare`` exits non-zero when anything
+differs, so it can be a gate; every difference it prints is either a bug in
+the fuzzer run, a gap in the database, or a tile type the law could not learn,
+and it is worth knowing which before the model is committed.
+
+The same three commands cross-check a model that is already committed: give
+``derive`` the committed ``tilegrid.json`` with ``--grid`` instead of a fresh
+dump, and it will rebuild the frame addresses from the grid the model itself
+carries.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,6 +46,7 @@ to develop a free and open Verilog to bitstream toolchain for these devices.
    db_dev_process/minitests/index
    db_dev_process/parts
    db_dev_process/newpart
+   db_dev_process/tilegrid_derivation
 
 .. toctree::
    :maxdepth: 2

--- a/utils/dump_grid.sh
+++ b/utils/dump_grid.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Copyright (C) 2017-2020  The Project X-Ray Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+#
+# Dump the tile grid of one part, in the format 005-tilegrid reads.
+#
+# This is 005-tilegrid's own generate_tiles.tcl, run on its own: since it
+# reads the grid off a device with nothing placed on it, it needs no ROI
+# design, no fuzzer build and no settings file for the part -- which is the
+# point, because a part that has no settings file yet is exactly the one whose
+# grid you want to look at.  Feed the result to
+# `utils/tilegrid_derive.py derive`, or diff it against the tiles.txt a
+# fuzzer run produced.
+#
+# usage: utils/dump_grid.sh <part> [output directory]
+#
+# Source a settings file of the family first (it is what sets XRAY_VIVADO).
+# XRAY_EXCLUDE_ROI_TILEGRID, the list of tiles to blank out, defaults to none.
+
+set -e
+
+part="${1:-${XRAY_PART}}"
+out="${2:-.}"
+
+if [ -z "${part}" ]; then
+    echo "usage: $0 <part> [output directory]" >&2
+    exit 1
+fi
+if [ -z "${XRAY_VIVADO}" ] || [ -z "${XRAY_FUZZERS_DIR}" ]; then
+    echo "$0: source a settings file of the family first" >&2
+    exit 1
+fi
+
+mkdir -p "${out}"
+cd "${out}"
+
+export XRAY_PART="${part}"
+export XRAY_EXCLUDE_ROI_TILEGRID="${XRAY_EXCLUDE_ROI_TILEGRID:-}"
+export FUZDIR="${XRAY_FUZZERS_DIR}/005-tilegrid"
+
+"${XRAY_VIVADO}" -mode batch -source "${FUZDIR}/generate_tiles.tcl" \
+    -nojournal -log dump_grid.log
+
+echo "$0: wrote $(pwd)/tiles.txt and $(pwd)/pin_func.txt for ${part}"

--- a/utils/test_tilegrid_derive.py
+++ b/utils/test_tilegrid_derive.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017-2020  The Project X-Ray Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+"""The calibration gate of utils/tilegrid_derive.py.
+
+The synthetic tests run anywhere.  The calibration test needs a database with
+device models in it -- `./download-latest-db.sh`, or XRAY_DATABASE_DIR
+pointing at a prjxray-db clone -- and is skipped when there is none, because
+the repository only carries the mapping files.
+
+What the calibration asserts is deliberately one-sided: every device model
+must be rebuilt byte for byte from its own grid, except the ones listed in
+KNOWN_DIFFERENCES, and those may only differ in the ways recorded there.  A
+device model that starts differing in a new way, or a new device model that
+does not reproduce at all, fails the gate; a database that gets *more* right
+than this table expects does not.
+"""
+
+import os
+import unittest
+
+from utils import tilegrid_derive
+from utils import tilegrid_model
+
+# The device models that rebuild byte for byte today, and how many bits
+# entries that is in total.  Recomputed from the run, not copied by hand.
+REPRODUCED = {
+    ('artix7', 'xc7a100t'),
+    ('artix7', 'xc7a50t'),
+    ('kintex7', 'xc7k160t'),
+    ('kintex7', 'xc7k325t'),
+    ('kintex7', 'xc7k420t'),
+    ('kintex7', 'xc7k480t'),
+    ('kintex7', 'xc7k70t'),
+    ('spartan7', 'xc7s50'),
+    ('zynq7', 'xc7z030'),
+    ('zynq7', 'xc7z045'),
+    ('zynq7', 'xc7z100'),
+}
+REPRODUCED_ENTRIES = 500405
+
+# Device models that cannot be rebuilt exactly, with the reason, and the
+# (tile type, kind) pairs the difference is allowed to appear in.
+KNOWN_DIFFERENCES = {
+    ('artix7', 'xc7a200t'): (
+        'the only artix7 device with GTP transceivers in the middle of the '
+        'die, so no other artix7 model can teach their geometry', {
+            ('GTP_CHANNEL_0_MID_LEFT', 'right-only'),
+            ('GTP_CHANNEL_0_MID_RIGHT', 'right-only'),
+            ('GTP_CHANNEL_1_MID_LEFT', 'right-only'),
+            ('GTP_CHANNEL_1_MID_RIGHT', 'right-only'),
+            ('GTP_CHANNEL_2_MID_LEFT', 'right-only'),
+            ('GTP_CHANNEL_2_MID_RIGHT', 'right-only'),
+            ('GTP_CHANNEL_3_MID_LEFT', 'right-only'),
+            ('GTP_CHANNEL_3_MID_RIGHT', 'right-only'),
+            ('GTP_COMMON_MID_LEFT', 'right-only'),
+            ('GTP_COMMON_MID_RIGHT', 'right-only'),
+            ('GTP_INT_INTERFACE_L', 'right-only'),
+            ('GTP_INT_INTERFACE_R', 'right-only')
+        }),
+    ('zynq7', 'xc7z020'): (
+        'the only zynq7 device model with a right-hand high-range I/O column '
+        '(xc7z010 has one but is refused), so nothing teaches which side of '
+        'those tiles their interconnect column is on', {
+            ('HCLK_IOI3', 'right-only'), ('RIOB33', 'right-only'),
+            ('RIOB33_SING', 'right-only'), ('RIOI3', 'right-only'),
+            ('RIOI3_SING', 'right-only'), ('RIOI3_TBYTESRC', 'right-only'),
+            ('RIOI3_TBYTETERM', 'right-only')
+        }),
+    ('spartan7', 'xc7s25'): (
+        'MONITOR_BOT_FUJI2 exists on no other spartan7 device, and the six '
+        'upper *_SING tiles carry the alias start_offset 2 that '
+        'generate_full.py has written since the VC707 fix while every older '
+        'committed model still says 0', {
+            ('MONITOR_BOT_FUJI2', 'right-only'), ('LIOB33_SING', 'differing'),
+            ('LIOI3_SING', 'differing'), ('RIOB33_SING', 'differing'),
+            ('RIOI3_SING', 'differing')
+        }),
+    ('spartan7', 'xc7s100'): (
+        'built before prjxray#16, so it carries the fingerprint of the '
+        'site-type-off-a-placed-design bug: CLK_BUFG_BOT_R measured five '
+        'words high, no address for CFG_CENTER_MID, and five LIOB33 tiles '
+        'the iob sub-fuzzer skipped', {
+            ('CLK_BUFG_BOT_R', 'differing'), ('CFG_CENTER_MID', 'left-only'),
+            ('LIOB33', 'left-only')
+        }),
+}
+
+# Device models that are not rebuilt at all, and why.
+NOT_REBUILT = {
+    ('zynq7', 'xc7z010'): 'refused',
+    ('virtex7', 'xc7vx485t'): 'skipped',
+}
+
+
+def database_dir():
+    """The database to calibrate against, or None."""
+    candidates = [os.getenv('XRAY_DATABASE_DIR')]
+    here = os.path.dirname(os.path.abspath(__file__))
+    candidates.append(os.path.join(here, os.pardir, 'database'))
+    for candidate in candidates:
+        if not candidate or not os.path.isdir(candidate):
+            continue
+        if any(tilegrid_derive.device_models(candidate)):
+            return candidate
+    return None
+
+
+def synthetic_device(columns=2, rows=1):
+    """A grid and a part.yaml body for a device with plain CLB columns only."""
+    grid = {}
+    for row in range(rows):
+        top = row * 51
+        for y in range(top, top + 51):
+            for column in range(columns):
+                x = column * 2
+                hclk = y == top + 25
+                grid['CLBLL_L_X%dY%d' % (x, y)] = {
+                    'type': 'HCLK_CLB' if hclk else 'CLBLL_L',
+                    'grid_x': x,
+                    'grid_y': y,
+                    'sites': {},
+                    'bits': {},
+                }
+                grid['INT_L_X%dY%d' % (x + 1, y)] = {
+                    'type': 'HCLK_L' if hclk else 'INT_L',
+                    'grid_x': x + 1,
+                    'grid_y': y,
+                    'sites': {},
+                    'bits': {},
+                }
+    part = {
+        'global_clock_regions': {
+            'top': {
+                'rows': {
+                    row: {
+                        'configuration_buses': {
+                            'CLB_IO_CLK': {
+                                'configuration_columns': {
+                                    column: {
+                                        'frame_count': 36
+                                    }
+                                    for column in range(columns)
+                                }
+                            }
+                        }
+                    }
+                    for row in range(rows)
+                }
+            }
+        }
+    }
+    return grid, part
+
+
+def address_synthetic(grid, part):
+    """Fill a synthetic grid the way the law says it should come out."""
+    rows = tilegrid_model.clock_row_of(grid)
+    row_map = tilegrid_model.part_rows(
+        part, len(tilegrid_model.clock_rows(grid)))
+    columns = tilegrid_model.anchor_columns(grid, 'CLB_IO_CLK')
+    for name, tile in grid.items():
+        row_index, row_position = rows[name]
+        bottom, row = row_map[row_index]
+        anchor = tile['grid_x'] if tile['type'].startswith(
+            ('INT_L', 'HCLK_L')) else tile['grid_x'] + 1
+        tile['bits'] = {
+            'CLB_IO_CLK': {
+                'baseaddr':
+                tilegrid_model.encode_baseaddr(
+                    0, bottom, row, columns.index(anchor)),
+                'frames':
+                36,
+                'offset':
+                2 * row_position,
+                'words':
+                2,
+            }
+        }
+    return grid
+
+
+class TestLaw(unittest.TestCase):
+    """The parts of the law that need no database."""
+
+    def test_baseaddr_round_trip(self):
+        for fields in ((0, 0, 0, 0), (0, 1, 0, 19), (1, 0, 3, 41), (1, 1, 15,
+                                                                    1023)):
+            self.assertEqual(
+                tilegrid_model.decode_baseaddr(
+                    tilegrid_model.encode_baseaddr(*fields)), fields)
+
+    def test_column_gate_counts_columns(self):
+        grid, part = synthetic_device(columns=3)
+        self.assertEqual(tilegrid_model.column_gate(grid, part), (True, 'ok'))
+        wider, _ = synthetic_device(columns=4)
+        ok, why = tilegrid_model.column_gate(wider, part)
+        self.assertFalse(ok)
+        self.assertIn('4 grid columns against 3', why)
+
+    def test_learn_and_reapply(self):
+        """The law learnt off a device rebuilds that device exactly."""
+        reference, part = synthetic_device(columns=3, rows=2)
+        address_synthetic(reference, part)
+        model = tilegrid_model.Model()
+        accepted, why = model.learn('synthetic', reference, part)
+        self.assertTrue(accepted, why)
+        model.resolve()
+        self.assertEqual(model.conflicts, [])
+
+        target, target_part = synthetic_device(columns=3, rows=2)
+        report = model.apply(target, target_part)
+        self.assertEqual(report['filled'], len(target))
+        counter, differences = tilegrid_model.diff_bits(target, reference)
+        self.assertEqual(differences, [])
+        self.assertEqual(counter['identical'], len(target))
+
+    def test_unknown_tile_type_gets_no_address(self):
+        """A tile type no reference carries is left alone, never guessed."""
+        reference, part = synthetic_device(columns=3)
+        address_synthetic(reference, part)
+        model = tilegrid_model.Model()
+        model.learn('synthetic', reference, part)
+        model.resolve()
+
+        target, target_part = synthetic_device(columns=3)
+        target['DSP_R_X0Y10'] = {
+            'type': 'DSP_R',
+            'grid_x': 0,
+            'grid_y': 10,
+            'sites': {},
+            'bits': {},
+        }
+        model.apply(target, target_part)
+        self.assertEqual(target['DSP_R_X0Y10']['bits'], {})
+
+
+@unittest.skipIf(database_dir() is None, 'no database with device models')
+class TestCalibration(unittest.TestCase):
+    """Leave-one-out reproduction of every device model in the database."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.results = {
+            (r.family, r.device): r
+            for r in tilegrid_derive.calibrate(database_dir())
+        }
+
+    def test_every_device_model_is_accounted_for(self):
+        for key, result in sorted(self.results.items()):
+            if key in NOT_REBUILT:
+                self.assertEqual(result.verdict, NOT_REBUILT[key], key)
+            elif key in KNOWN_DIFFERENCES:
+                self.assertIn(result.verdict, ('exact', 'differs'), key)
+            else:
+                self.assertEqual(
+                    result.verdict, 'exact',
+                    '%s does not rebuild byte for byte; if that is expected, '
+                    'record it in KNOWN_DIFFERENCES with the reason' % (key, ))
+
+    def test_the_recorded_device_models_still_reproduce(self):
+        for key in sorted(REPRODUCED):
+            self.assertIn(key, self.results)
+            self.assertEqual(self.results[key].verdict, 'exact', key)
+        reproduced = sum(
+            r.counter['identical']
+            for r in self.results.values()
+            if r.verdict == 'exact')
+        self.assertGreaterEqual(reproduced, REPRODUCED_ENTRIES)
+
+    def test_known_differences_stay_where_they_are(self):
+        for key, (reason, allowed) in sorted(KNOWN_DIFFERENCES.items()):
+            if key not in self.results:
+                continue
+            seen = {
+                (tile_type, kind)
+                for _, tile_type, _, kind, _, _ in self.results[key].
+                differences
+            }
+            self.assertTrue(
+                seen <= allowed,
+                '%s differs in a new way (%s); the recorded reason is: %s' %
+                (key, sorted(seen - allowed), reason))
+
+    def test_no_geometry_is_settled_by_a_coin_toss(self):
+        for key, result in sorted(self.results.items()):
+            if result.model is None:
+                continue
+            self.assertEqual(
+                [c.describe() for c in result.model.unresolved_conflicts()],
+                [], key)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/utils/tilegrid_derive.py
+++ b/utils/tilegrid_derive.py
@@ -1,0 +1,513 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017-2020  The Project X-Ray Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+"""Derive a device tilegrid from a Vivado grid dump, and check the law it uses.
+
+Three commands:
+
+calibrate
+    Leave one device model out of the database, learn the frame-address law
+    from the rest of its family, rebuild the model from its grid alone and
+    diff it against the committed file.  Needs no Vivado.  This is the gate:
+    a law that cannot rebuild the models we already trust has no business
+    building one we cannot check.
+
+derive
+    Apply the law to a grid dumped from Vivado (fuzzers/005-tilegrid's own
+    generate_tiles.tcl writes it) and write a tilegrid.json.
+
+compare
+    Diff the `bits` of two tilegrid.json files, tile by tile.
+
+The intended use is as a second opinion on 005-tilegrid: run the fuzzer,
+derive the same device, and compare.  Where the two agree the model is
+measured twice over; where they disagree one of them is wrong, and the
+disagreement says which tile to look at.  Running `derive` against the
+committed model of a device that was never fuzzed is also how a model built
+for the wrong device shows itself -- that is how the committed xc7s25 and
+xc7s75 models were caught carrying the xc7s50 fabric.
+
+Examples::
+
+    utils/tilegrid_derive.py calibrate --database-dir database
+    utils/tilegrid_derive.py derive --db-root database/spartan7 \\
+        --part xc7s25csga324-1 --tiles tiles.txt --pin-func pin_func.txt \\
+        --output xc7s25-derived.json
+    utils/tilegrid_derive.py compare database/spartan7/xc7s25/tilegrid.json \\
+        xc7s25-derived.json --labels fuzzed derived
+"""
+
+import argparse
+import collections
+import json
+import os
+import sys
+
+from prjxray import util
+from utils import tilegrid_model
+from utils import xjson
+
+# A device model lives in <family>/<device>/tilegrid.json; the frame layout it
+# has to be checked against lives in the part.yaml of one of that device's
+# parts.  Only the fully fuzzed part carries global_clock_regions, the others
+# are stubs, so picking the first such part in sorted order is deterministic
+# and picks the same part on every run.
+TILEGRID = 'tilegrid.json'
+PART_YAML = 'part.yaml'
+
+
+def device_models(database_dir, family=None):
+    """Yield (family, device) for every device model in a database."""
+    for fam in sorted(os.listdir(database_dir)):
+        if family is not None and fam != family:
+            continue
+        family_dir = os.path.join(database_dir, fam)
+        if not os.path.isdir(family_dir):
+            continue
+        for device in sorted(os.listdir(family_dir)):
+            if os.path.isfile(os.path.join(family_dir, device, TILEGRID)):
+                yield fam, device
+
+
+def part_of(family_dir, device):
+    """The part whose part.yaml carries the frame layout of `device`."""
+    for entry in sorted(os.listdir(family_dir)):
+        if not entry.startswith(device) or entry == device:
+            continue
+        path = os.path.join(family_dir, entry, PART_YAML)
+        if not os.path.isfile(path):
+            continue
+        with open(path) as f:
+            if 'global_clock_regions' in f.read():
+                return entry
+    return None
+
+
+def read_grid(path):
+    with open(path) as f:
+        return json.load(f)
+
+
+def strip_bits(grid):
+    """A copy of a grid with every frame address removed."""
+    bare = json.loads(json.dumps(grid))
+    for tile in bare.values():
+        tile['bits'] = {}
+    return bare
+
+
+def learn(model, family_dir, device):
+    """Add one device model of one family to `model`.  Returns (ok, why)."""
+    part = part_of(family_dir, device)
+    if part is None:
+        model.rejected.append((device, 'no part.yaml with a frame layout'))
+        return False, 'no part.yaml with a frame layout'
+    grid = read_grid(os.path.join(family_dir, device, TILEGRID))
+    part_yaml = tilegrid_model.load_part(
+        os.path.join(family_dir, part, PART_YAML))
+    return model.learn(device, grid, part_yaml)
+
+
+def learn_references(family_dir, references, elsewhere=None):
+    """Learn the law of one family from the named device models."""
+    model = tilegrid_model.Model()
+    for device in references:
+        learn(model, family_dir, device)
+    model.resolve(elsewhere)
+    return model
+
+
+def learn_families(database_dir):
+    """family -> a Model holding every device model of that family."""
+    models = {}
+    for family, device in device_models(database_dir):
+        model = models.setdefault(family, tilegrid_model.Model())
+        learn(model, os.path.join(database_dir, family), device)
+    return models
+
+
+def learn_elsewhere(family_models, family):
+    """One resolved Model holding every device model of the OTHER families.
+
+    It settles ties inside a family, and -- only where asked to -- lends a
+    geometry for a tile type the family itself has no reference for.  Keeping
+    the family out of it is what makes calibration a real leave-one-out: a
+    device never votes on itself, not even through a sibling.
+    """
+    model = tilegrid_model.Model()
+    for other, other_model in sorted(family_models.items()):
+        if other != family:
+            model.merge(other_model)
+    model.resolve()
+    return model
+
+
+def print_rejected(model, indent=''):
+    for device, why in model.rejected:
+        print('%snot used as a reference: %s (%s)' % (indent, device, why))
+
+
+def print_conflicts(model, indent=''):
+    if not model.conflicts:
+        return
+    print(
+        '%s%d tile geometries the reference models disagree on '
+        '(the winner is listed first):' % (indent, len(model.conflicts)))
+    for conflict in model.conflicts:
+        for line in conflict.describe().split('\n'):
+            print('%s%s' % (indent, line))
+
+
+def difference_breakdown(differences):
+    """(tile_type, kind) -> count, for the per-type table."""
+    counter = {}
+    for _, tile_type, _, kind, _, _ in differences:
+        counter[(tile_type, kind)] = counter.get((tile_type, kind), 0) + 1
+    return counter
+
+
+Calibration = collections.namedtuple(
+    'Calibration',
+    'family device part verdict reason counter differences report model notes')
+
+HEADER = (
+    '%-9s %-11s %-9s %-20s %8s %9s %9s %9s %9s' % (
+        'family', 'device', 'verdict', 'part', 'entries', 'identical',
+        'differing', 'missing', 'extra'))
+
+
+def calibrate(database_dir, family=None, device=None, fallback=False):
+    """Leave one device model out at a time and rebuild it from its grid.
+
+    Yields one Calibration per device model.  The verdict is 'exact' when the
+    rebuilt model matches the committed one byte for byte, 'differs' when it
+    does not, 'refused' when the committed model does not match its own
+    part.yaml, and 'skipped' when there is nothing to learn from.
+    """
+    by_family = {}
+    for fam, dev in device_models(database_dir):
+        by_family.setdefault(fam, []).append(dev)
+    family_models = learn_families(database_dir)
+    elsewhere = {}
+
+    for fam, dev in device_models(database_dir, family):
+        if device is not None and dev != device:
+            continue
+        family_dir = os.path.join(database_dir, fam)
+        with open(os.path.join(family_dir, dev, TILEGRID), 'rb') as f:
+            committed_bytes = f.read()
+
+        notes = []
+        references = []
+        for other in by_family[fam]:
+            if other == dev:
+                continue
+            with open(os.path.join(family_dir, other, TILEGRID), 'rb') as f:
+                if f.read() == committed_bytes:
+                    notes.append(
+                        '%s is a byte copy of this model, not used as a '
+                        'reference' % other)
+                    continue
+            references.append(other)
+
+        part = part_of(family_dir, dev)
+        if not references or part is None:
+            reason = (
+                'no other device model in the family'
+                if not references else 'no part.yaml with a frame layout')
+            yield Calibration(
+                fam, dev, part, 'skipped', reason, collections.Counter(), [],
+                collections.Counter(), None, notes)
+            continue
+
+        if fam not in elsewhere:
+            elsewhere[fam] = learn_elsewhere(family_models, fam)
+        model = learn_references(family_dir, references, elsewhere[fam])
+        committed = json.loads(committed_bytes.decode('utf-8'))
+        part_yaml = tilegrid_model.load_part(
+            os.path.join(family_dir, part, PART_YAML))
+
+        ok, why = tilegrid_model.column_gate(committed, part_yaml)
+        if not ok:
+            yield Calibration(
+                fam, dev, part, 'refused', why, collections.Counter(), [],
+                collections.Counter(), model, notes)
+            continue
+
+        derived = strip_bits(committed)
+        report = model.apply(
+            derived, part_yaml, elsewhere[fam] if fallback else None)
+        counter, differences = tilegrid_model.diff_bits(derived, committed)
+        exact = not (
+            counter['differing'] or counter['left-only']
+            or counter['right-only'])
+        yield Calibration(
+            fam, dev, part, 'exact' if exact else 'differs', '', counter,
+            differences, report, model, notes)
+
+
+def cmd_calibrate(args):
+    print(HEADER)
+    verdicts = {}
+    for result in calibrate(args.database_dir, args.family, args.device,
+                            args.cross_family_fallback):
+        for note in result.notes:
+            print('%-9s %-11s note: %s' % (result.family, result.device, note))
+        verdicts[(result.family, result.device)] = (
+            result.verdict, result.counter['identical'])
+        if result.verdict in ('skipped', 'refused'):
+            print(
+                '%-9s %-11s %-9s %-20s %s' % (
+                    result.family, result.device, result.verdict, result.part
+                    or '', result.reason))
+            continue
+        print(
+            '%-9s %-11s %-9s %-20s %8d %9d %9d %9d %9d' % (
+                result.family, result.device, result.verdict, result.part,
+                result.counter['identical'] + len(result.differences),
+                result.counter['identical'], result.counter['differing'],
+                result.counter['right-only'], result.counter['left-only']))
+        for kind in ('no-column', 'ambiguous-column', 'column-not-in-part',
+                     'filled-from-other-families'):
+            if result.report[kind]:
+                print('    %-26s %d tiles' % (kind, result.report[kind]))
+        if result.verdict != 'exact' or args.verbose:
+            for (tile_type, kind), count in sorted(difference_breakdown(
+                    result.differences).items()):
+                print('    %-40s %-10s %d' % (tile_type, kind, count))
+        if args.verbose:
+            print_rejected(result.model, '    ')
+            print_conflicts(result.model, '    ')
+        elif result.model.unresolved_conflicts():
+            print(
+                '    %d tile geometries no vote could settle; run with '
+                '--verbose' % len(result.model.unresolved_conflicts()))
+
+    counts = {}
+    for verdict in verdicts.values():
+        counts[verdict[0]] = counts.get(verdict[0], 0) + 1
+    reproduced = sum(n for v, n in verdicts.values() if v == 'exact')
+    print(
+        'summary: %d device models, %s; %d bits entries reproduced byte for '
+        'byte' % (
+            len(verdicts), ', '.join(
+                '%d %s' % (n, v) for v, n in sorted(counts.items())),
+            reproduced))
+    return 0
+
+
+def cmd_derive(args):
+    family_dir = os.path.abspath(args.db_root)
+    database_dir = os.path.dirname(family_dir)
+    family = os.path.basename(family_dir)
+    family_devices = [d for _, d in device_models(database_dir, family)]
+
+    # A device never derives itself: drop the fabric this part already maps
+    # to, so re-deriving a committed model really is a second opinion.
+    try:
+        own = util.get_fabric_for_part(family_dir, args.part)
+    except (AssertionError, KeyError):
+        own = None
+    references = args.reference
+    if not references:
+        references = [d for d in family_devices if d != own]
+        print('references: %s' % (' '.join(references) or 'none'))
+    elif own in references:
+        print(
+            'warning: %s is the fabric %s already maps to; deriving it from '
+            'itself proves nothing' % (own, args.part))
+    part_yaml = tilegrid_model.load_part(
+        os.path.join(family_dir, args.part, PART_YAML))
+
+    if args.grid:
+        grid = strip_bits(read_grid(args.grid))
+    else:
+        grid = tilegrid_model.load_grid(args.tiles, args.pin_func)
+    print('grid: %d tiles from %s' % (len(grid), args.grid or args.tiles))
+
+    family_models = learn_families(database_dir)
+    elsewhere = learn_elsewhere(family_models, family)
+    model = learn_references(family_dir, references, elsewhere)
+    print('law learnt from %s' % ' '.join(model.references))
+    print_rejected(model)
+    print_conflicts(model)
+
+    ok, why = tilegrid_model.column_gate(grid, part_yaml)
+    print('column gate against %s: %s' % (args.part, why))
+    if not ok:
+        print(
+            'ERROR: the grid and the part.yaml describe different devices, '
+            'so the column rule does not hold here.',
+            file=sys.stderr)
+        return 1
+
+    rows = tilegrid_model.clock_row_of(grid)
+    used = set()
+    for name, tile in grid.items():
+        if name not in rows:
+            continue
+        _, row_position = rows[name]
+        for bus in tilegrid_model.BUSES:
+            used.add((tile['type'], row_position, bus))
+    unsettled = [
+        c for c in model.unresolved_conflicts()
+        if (c.tile_type, c.row_position, c.bus) in used
+    ]
+    if unsettled and not args.allow_reference_conflicts:
+        print(
+            'ERROR: %d tile geometries this grid uses are ones the reference '
+            'models disagree on and no vote could settle; narrow --reference, '
+            'or pass --allow-reference-conflicts to take the first one given.'
+            % len(unsettled),
+            file=sys.stderr)
+        return 1
+
+    report = model.apply(
+        grid, part_yaml, elsewhere if args.cross_family_fallback else None)
+    unplaced = ', '.join(
+        '%s %d' % (k, report[k])
+        for k in ('no-column', 'ambiguous-column', 'column-not-in-part')
+        if report[k])
+    print(
+        'filled %d frame addresses; %s' %
+        (report['filled'], unplaced or 'no tile left unplaced'))
+    if report['filled-from-other-families']:
+        print(
+            '%d of them borrowed from the other families, for tile types this '
+            'family has no reference for' %
+            report['filled-from-other-families'])
+    without_bits = {t['type'] for t in grid.values() if not t.get('bits')}
+    addressed = {key[0] for key in elsewhere.observations}
+    addressed |= {key[0] for key in model.observations}
+    notable = sorted(without_bits & addressed)
+    print(
+        '%d tile types got no frame address; %d of them are addressed on '
+        'other devices in this database%s' % (
+            len(without_bits), len(notable),
+            ': ' + ' '.join(notable) if notable else ''))
+    with open(args.output, 'w') as f:
+        xjson.pprint(f, grid)
+    print('wrote %s' % args.output)
+    return 0
+
+
+def cmd_compare(args):
+    left = read_grid(args.left)
+    right = read_grid(args.right)
+    llabel, rlabel = args.labels
+    counter, differences = tilegrid_model.diff_bits(left, right)
+    print(
+        '%s: %d tiles, %s: %d tiles, same tile names: %s' %
+        (llabel, len(left), rlabel, len(right), set(left) == set(right)))
+    print(
+        '%d bits entries identical, %d differing, %d only in %s, %d only in %s'
+        % (
+            counter['identical'], counter['differing'], counter['left-only'],
+            llabel, counter['right-only'], rlabel))
+    for (tile_type,
+         kind), count in sorted(difference_breakdown(differences).items()):
+        print('    %-40s %-12s %d' % (tile_type, kind, count))
+    for name, _, bus, kind, lbits, rbits in differences[:args.examples]:
+        print('  %s %s (%s)' % (name, bus, kind))
+        print('    %-8s %s' % (llabel, json.dumps(lbits, sort_keys=True)))
+        print('    %-8s %s' % (rlabel, json.dumps(rbits, sort_keys=True)))
+    return 1 if differences else 0
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__.split('\n')[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog='\n'.join(__doc__.split('\n')[2:]))
+    commands = parser.add_subparsers(dest='command')
+    commands.required = True
+
+    calibrate = commands.add_parser(
+        'calibrate',
+        help='leave-one-out reproduction of every device model in a database')
+    calibrate.add_argument(
+        '--database-dir',
+        default=os.getenv('XRAY_DATABASE_DIR'),
+        required=os.getenv('XRAY_DATABASE_DIR') is None,
+        help='database root, the directory holding the family directories. '
+        'Defaults to XRAY_DATABASE_DIR.')
+    calibrate.add_argument('--family', help='only this family')
+    calibrate.add_argument('--device', help='only this device model')
+    calibrate.add_argument(
+        '--cross-family-fallback',
+        action='store_true',
+        help='for a tile type the family has no reference for, borrow the '
+        'geometry from the other families instead of leaving it unaddressed')
+    calibrate.add_argument(
+        '--verbose',
+        action='store_true',
+        help='list every reference and the per-tile-type breakdown')
+    calibrate.set_defaults(func=cmd_calibrate)
+
+    derive = commands.add_parser(
+        'derive', help='build a tilegrid.json for a device from its grid')
+    util.db_root_arg(derive)
+    util.part_arg(derive)
+    derive.add_argument(
+        '--tiles', help='tiles.txt, as written by 005-tilegrid')
+    derive.add_argument(
+        '--pin-func', help='pin_func.txt, as written by 005-tilegrid')
+    derive.add_argument(
+        '--grid',
+        help='take the grid from an existing tilegrid.json instead of a dump; '
+        'its frame addresses are discarded')
+    derive.add_argument(
+        '--reference',
+        action='append',
+        default=[],
+        help='device model to learn the law from; repeatable, and a comma '
+        'separated list is accepted. Defaults to every device model of the '
+        'family except the one this part is already a part of.')
+    derive.add_argument(
+        '--output', required=True, help='tilegrid.json to write')
+    derive.add_argument(
+        '--cross-family-fallback',
+        action='store_true',
+        help='for a tile type the family has no reference for, borrow the '
+        'geometry from the other families instead of leaving it unaddressed')
+    derive.add_argument(
+        '--allow-reference-conflicts',
+        action='store_true',
+        help='derive even where the reference models disagree')
+    derive.set_defaults(func=cmd_derive)
+
+    compare = commands.add_parser(
+        'compare', help='diff the frame addresses of two tilegrid.json files')
+    compare.add_argument('left', help='a tilegrid.json')
+    compare.add_argument('right', help='another tilegrid.json')
+    compare.add_argument(
+        '--labels', nargs=2, default=['left', 'right'], help='names to print')
+    compare.add_argument(
+        '--examples',
+        type=int,
+        default=8,
+        help='how many differing entries to print in full')
+    compare.set_defaults(func=cmd_compare)
+
+    args = parser.parse_args()
+    if args.command == 'derive':
+        if args.grid and (args.tiles or args.pin_func):
+            parser.error('--grid and --tiles/--pin-func are alternatives')
+        if not args.grid and not (args.tiles and args.pin_func):
+            parser.error('give either --grid or both --tiles and --pin-func')
+        flat = []
+        for reference in args.reference:
+            flat.extend(r for r in reference.split(',') if r)
+        args.reference = flat
+    return args.func(args)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/utils/tilegrid_model.py
+++ b/utils/tilegrid_model.py
@@ -1,0 +1,473 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017-2020  The Project X-Ray Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+"""Learn the 7-series tilegrid frame-address law from the device models a
+database already holds, and apply it to a device grid.
+
+The law, per family::
+
+    baseaddr = (block_type << 23) | (bottom << 22) | (row << 17) | (column << 7)
+
+column
+    The rank of the tile's own configuration column, counted left to right
+    over the grid columns that carry an interconnect tile (``INT_L`` /
+    ``INT_R`` / ``INT_FEEDTHRU_2``) for the ``CLB_IO_CLK`` bus, or a block-RAM
+    tile (``BRAM_L`` / ``BRAM_R``) for the ``BLOCK_RAM`` bus.  Which of those
+    columns a tile belongs to is a fixed per-tile-type grid_x delta -- a
+    ``CLBLL_L`` sits one column left of its ``INT_L``, a ``DSP_R`` two columns
+    right of its ``INT_R`` -- learned from the reference models.
+
+bottom, row
+    The clock-region row the tile lives in, numbered outward from the middle
+    of the device.  Which rows exist in each half comes from ``part.yaml``.
+
+offset, words, frames
+    A fixed function of the tile type and of the tile's vertical position
+    inside its clock-region row, again learned from the reference models.
+    ``frames`` is capped by the column's own ``frame_count``, the way
+    ``fuzzers/005-tilegrid/util.py`` caps it.
+
+Everything the model knows is measured: it comes out of tilegrids that
+``005-tilegrid`` produced against real silicon.  Nothing here guesses at a
+device nobody has looked at -- a tile type no reference model carries gets no
+address at all, and a reference whose grid disagrees with its own
+``part.yaml`` is refused rather than averaged in.  The check that this is the
+law and not an accident is leave-one-out reproduction of every device model in
+the database (``utils/tilegrid_derive.py calibrate``).
+"""
+
+import collections
+import copy
+import importlib.util
+import json
+import os
+
+from utils import xyaml
+
+# The configuration buses a tilegrid addresses.  CFG_CLB (block type 2) is
+# never part of a tilegrid entry, so only these two are modelled.
+BUSES = ('CLB_IO_CLK', 'BLOCK_RAM')
+BLOCK_TYPE = {'CLB_IO_CLK': 0, 'BLOCK_RAM': 1}
+
+# A configuration column is anchored on its interconnect column.  Where a hard
+# block (the configuration centre) interrupts the fabric, the interconnect is
+# replaced by a feed-through tile: INT_FEEDTHRU_2 sits exactly where the INT_L
+# or INT_R would, and INT_FEEDTHRU_1 where the logic tile would.  The column
+# still exists in the bitstream and still consumes a column index, which is why
+# xc7s25 declares 38 configuration columns while only 32 of them carry
+# interconnect.
+INT_TYPES = ('INT_L', 'INT_R', 'INT_FEEDTHRU_2')
+BRAM_TYPES = ('BRAM_L', 'BRAM_R')
+ANCHOR_TYPES = {'CLB_IO_CLK': INT_TYPES, 'BLOCK_RAM': BRAM_TYPES}
+
+# A clock-region row is 50 tile rows tall, centred on its HCLK row.
+CLOCK_ROW_HALF_HEIGHT = 25
+
+
+def decode_baseaddr(baseaddr):
+    """Split a tilegrid base address into (block_type, bottom, row, column).
+
+    >>> decode_baseaddr('0x0040099B')
+    (0, 1, 0, 19)
+    >>> decode_baseaddr('0x00800100')
+    (1, 0, 0, 2)
+    """
+    a = int(baseaddr, 0)
+    return ((a >> 23) & 0x7, (a >> 22) & 1, (a >> 17) & 0x1F, (a >> 7) & 0x3FF)
+
+
+def encode_baseaddr(block_type, bottom, row, column):
+    """Build a tilegrid base address out of its four fields.
+
+    >>> encode_baseaddr(0, 1, 0, 19)
+    '0x00400980'
+    >>> decode_baseaddr(encode_baseaddr(1, 0, 2, 5))
+    (1, 0, 2, 5)
+    """
+    return '0x%08X' % (
+        (block_type << 23) | (bottom << 22) | (row << 17) | (column << 7))
+
+
+def clock_rows(grid):
+    """grid_y of every HCLK row of a grid, top of the device first."""
+    return sorted(
+        {t['grid_y']
+         for t in grid.values()
+         if t['type'].startswith('HCLK')})
+
+
+def clock_row_of(grid, hclk_ys=None):
+    """tile name -> (index of its clock-region row, position inside that row)
+
+    The position is counted upward from the bottom of the clock region, which
+    is how the tile geometry repeats: the tile at the very bottom of every
+    clock region has the same offset and word count wherever it sits.
+    """
+    if hclk_ys is None:
+        hclk_ys = clock_rows(grid)
+    out = {}
+    for name, tile in grid.items():
+        gy = tile['grid_y']
+        for i, hy in enumerate(hclk_ys):
+            if hy - CLOCK_ROW_HALF_HEIGHT <= gy <= hy + CLOCK_ROW_HALF_HEIGHT:
+                out[name] = (i, hy + CLOCK_ROW_HALF_HEIGHT - gy)
+                break
+    return out
+
+
+def anchor_columns(grid, bus):
+    """sorted grid_x of the columns that anchor a configuration column of `bus`"""
+    types = ANCHOR_TYPES[bus]
+    return sorted({t['grid_x'] for t in grid.values() if t['type'] in types})
+
+
+def part_rows(part, n_clock_rows):
+    """clock-row index (top of the device first) -> (bottom flag, row number)
+
+    part.yaml enumerates which rows exist in each half.  Rows are numbered
+    outward from the middle of the device, so the grid's lower clock rows are
+    the 'bottom' half in ascending row order going down, and the rest are the
+    'top' half in ascending row order going up.
+    """
+    gcr = part['global_clock_regions']
+    bottom_rows = sorted(int(r) for r in gcr.get('bottom', {}).get('rows', {}))
+    top_rows = sorted(int(r) for r in gcr.get('top', {}).get('rows', {}))
+    assert len(bottom_rows) + len(top_rows) == n_clock_rows, (
+        bottom_rows, top_rows, n_clock_rows)
+    out = {}
+    for i, r in enumerate(reversed(top_rows)):
+        out[i] = (0, r)
+    for j, r in enumerate(bottom_rows):
+        out[len(top_rows) + j] = (1, r)
+    return out
+
+
+def part_frame_counts(part):
+    """(bottom, row, bus, column) -> frame_count, straight out of part.yaml"""
+    out = {}
+    for half, gcr in part['global_clock_regions'].items():
+        bottom = 1 if half == 'bottom' else 0
+        for row, rowd in gcr['rows'].items():
+            for bus, busd in rowd['configuration_buses'].items():
+                for col, cold in busd['configuration_columns'].items():
+                    key = (bottom, int(row), bus, int(col))
+                    out[key] = cold['frame_count']
+    return out
+
+
+def column_gate(grid, part):
+    """Check that a grid and a part.yaml describe the same device.
+
+    The column rule holds only where the fabric spans the whole device: the
+    number of anchor columns in the grid must equal the number of
+    configuration columns part.yaml declares for the widest row, and the two
+    must agree on how many clock-region rows there are.
+
+    It refuses xc7z010, whose PS7 swallows 24 configuration columns down the
+    left-hand side, and it is what catches a device model that was built for
+    another device: it is how the committed xc7s25 and xc7s75 models were
+    found to be the xc7s50 fabric (44 interconnect columns in the grid against
+    the 38 and 54 their own part.yaml declares).
+
+    Returns (ok, reason).
+    """
+    declared = {}
+    for (_, _, bus, col) in part_frame_counts(part):
+        declared[bus] = max(declared.get(bus, 0), col + 1)
+    for bus in BUSES:
+        n = len(anchor_columns(grid, bus))
+        if n != declared.get(bus, 0):
+            return False, '%s: %d grid columns against %d in part.yaml' % (
+                bus, n, declared.get(bus, 0))
+    n_rows = sum(
+        len(half['rows']) for half in part['global_clock_regions'].values())
+    if n_rows != len(clock_rows(grid)):
+        return False, 'rows: %d HCLK rows in the grid against %d in part.yaml' % (
+            len(clock_rows(grid)), n_rows)
+    return True, 'ok'
+
+
+class Conflict(collections.namedtuple(
+        'Conflict', 'tile_type row_position bus alternatives resolution')):
+    """Reference models that disagree on the geometry of one tile type.
+
+    `alternatives` is a list of (geometry, [devices], outside_votes), the one
+    that won first.  `resolution` says how it won: 'majority' (most devices in
+    the family), 'other families' (the family was split evenly and the models
+    of the other families broke the tie) or 'arbitrary' (nothing broke the
+    tie, so the first reference given won and the answer is a guess).
+    """
+
+    def describe(self):
+        lines = [
+            '%s row_position=%d %s -- resolved by %s' %
+            (self.tile_type, self.row_position, self.bus, self.resolution)
+        ]
+        for geom, devices, outside in self.alternatives:
+            lines.append(
+                '    %-40s %s%s' % (
+                    json.dumps(geom, sort_keys=True), ' '.join(devices),
+                    ' (+%d elsewhere)' % outside if outside else ''))
+        return '\n'.join(lines)
+
+
+class Model:
+    """The frame-address law, learned from reference device models."""
+
+    def __init__(self):
+        # (bus, tile_type) -> ordered set of grid_x deltas to the anchor column
+        self.deltas = collections.defaultdict(dict)
+        # (tile_type, row_position, bus) -> {geometry key -> [(device, geom)]}
+        self.observations = collections.defaultdict(
+            lambda: collections.OrderedDict())
+        self.geometry = {}
+        self.conflicts = []
+        self.references = []
+        self.rejected = []
+
+    def learn(self, device, grid, part):
+        """Add one reference device model.  Returns (accepted, reason)."""
+        ok, why = column_gate(grid, part)
+        if not ok:
+            self.rejected.append((device, why))
+            return False, why
+        rows = clock_row_of(grid)
+        columns = {bus: anchor_columns(grid, bus) for bus in BUSES}
+        for name, tile in sorted(grid.items()):
+            if name not in rows:
+                continue
+            _, row_position = rows[name]
+            for bus, bits in sorted(tile.get('bits', {}).items()):
+                if bus not in BUSES:
+                    continue
+                _, _, _, column = decode_baseaddr(bits['baseaddr'])
+                if column >= len(columns[bus]):
+                    # Cannot place the tile in a grid column: the model and
+                    # the grid disagree, so learn nothing from this tile.
+                    continue
+                delta = tile['grid_x'] - columns[bus][column]
+                self.deltas[(bus, tile['type'])][delta] = True
+                geom = {
+                    'offset': bits['offset'],
+                    'words': bits['words'],
+                    'frames': bits['frames'],
+                }
+                if 'alias' in bits:
+                    geom['alias'] = copy.deepcopy(bits['alias'])
+                key = (tile['type'], row_position, bus)
+                self.observations[key].setdefault(_geometry_key(geom),
+                                                  []).append((device, geom))
+        self.references.append(device)
+        self.geometry = {}
+        self.conflicts = []
+        return True, 'ok'
+
+    def resolve(self, tiebreaker=None):
+        """Turn the observations into one geometry per key.
+
+        Observations that differ only in `frames` are the same geometry seen
+        in columns of different depth; the deepest wins, and apply() caps it
+        again per column.  Anything else is a genuine disagreement between
+        reference models, and it is resolved in this order:
+
+        1. the geometry the most devices of the family agree on;
+        2. if the family is split evenly, the geometry the models in
+           `tiebreaker` agree on -- pass a model built from the *other*
+           families, so a device never gets to vote on itself;
+        3. if that is split too, the first reference given wins and the
+           conflict is marked 'arbitrary'.
+
+        Every disagreement is recorded in self.conflicts whichever way it
+        went, because a model standing alone against the rest of the database
+        is exactly what this tool is meant to surface.
+        """
+        self.geometry = {}
+        self.conflicts = []
+        for key, alternatives in sorted(self.observations.items()):
+            merged = []
+            for geometry_key, observations in alternatives.items():
+                geom = dict(observations[0][1])
+                geom['frames'] = max(g['frames'] for _, g in observations)
+                devices = sorted({d for d, _ in observations})
+                merged.append(
+                    (
+                        geom, devices,
+                        _outside_votes(tiebreaker, key, geometry_key)))
+            top = max(len(m[1]) for m in merged)
+            leaders = [m for m in merged if len(m[1]) == top]
+            resolution = 'majority'
+            if len(leaders) > 1:
+                best_outside = max(m[2] for m in leaders)
+                outside_leaders = [m for m in leaders if m[2] == best_outside]
+                resolution = (
+                    'other families' if best_outside
+                    and len(outside_leaders) == 1 else 'arbitrary')
+                leaders = outside_leaders
+            winner = leaders[0]
+            self.geometry[key] = winner[0]
+            if len(merged) > 1:
+                ordered = [winner] + [m for m in merged if m is not winner]
+                self.conflicts.append(
+                    Conflict(key[0], key[1], key[2], ordered, resolution))
+        return self.conflicts
+
+    def merge(self, other):
+        """Fold another Model's observations into this one."""
+        for key, deltas in other.deltas.items():
+            self.deltas[key].update(deltas)
+        for key, alternatives in other.observations.items():
+            for geometry_key, observations in alternatives.items():
+                self.observations[key].setdefault(geometry_key,
+                                                  []).extend(observations)
+        self.references.extend(other.references)
+        self.rejected.extend(other.rejected)
+        self.geometry = {}
+        self.conflicts = []
+        return self
+
+    def unresolved_conflicts(self):
+        return [c for c in self.conflicts if c.resolution == 'arbitrary']
+
+    def apply(self, grid, part, fallback=None):
+        """Fill in the `bits` of a grid, in place.  Returns a Counter report.
+
+        A tile type no reference model of the family carries gets no address
+        at all -- unless `fallback` is given, in which case a second resolved
+        model (the rest of the database) is asked for that tile type alone.
+        Those entries are counted separately in the report: they are the ones
+        that rest on another family behaving the same way.
+        """
+        if not self.geometry:
+            self.resolve()
+        rows = clock_row_of(grid)
+        columns = {bus: anchor_columns(grid, bus) for bus in BUSES}
+        row_map = part_rows(part, len(clock_rows(grid)))
+        frame_counts = part_frame_counts(part)
+        report = collections.Counter()
+        for name, tile in sorted(grid.items()):
+            if name not in rows:
+                report['outside-any-clock-row'] += 1
+                continue
+            row_index, row_position = rows[name]
+            bottom, row = row_map[row_index]
+            for bus in BUSES:
+                key = (tile['type'], row_position, bus)
+                geom = self.geometry.get(key)
+                deltas = self.deltas.get((bus, tile['type']))
+                borrowed = False
+                if geom is None and fallback is not None:
+                    geom = fallback.geometry.get(key)
+                    deltas = fallback.deltas.get((bus, tile['type']))
+                    borrowed = geom is not None
+                if geom is None or not deltas:
+                    continue
+                candidates = [tile['grid_x'] - d for d in sorted(deltas)]
+                hits = [x for x in candidates if x in columns[bus]]
+                if len(hits) != 1:
+                    report['ambiguous-column' if hits else 'no-column'] += 1
+                    continue
+                column = columns[bus].index(hits[0])
+                column_key = (bottom, row, bus, column)
+                if column_key not in frame_counts:
+                    report['column-not-in-part'] += 1
+                    continue
+                entry = {
+                    'baseaddr':
+                    encode_baseaddr(BLOCK_TYPE[bus], bottom, row, column),
+                    'frames':
+                    min(geom['frames'], frame_counts[column_key]),
+                    'offset':
+                    geom['offset'],
+                    'words':
+                    geom['words'],
+                }
+                if 'alias' in geom:
+                    entry['alias'] = copy.deepcopy(geom['alias'])
+                tile.setdefault('bits', {})[bus] = entry
+                report['filled'] += 1
+                if borrowed:
+                    report['filled-from-other-families'] += 1
+        return report
+
+
+def _outside_votes(tiebreaker, key, geometry_key):
+    """How many devices outside the family agree with one geometry."""
+    if tiebreaker is None:
+        return 0
+    observations = tiebreaker.observations.get(key, {}).get(geometry_key, [])
+    return len({device for device, _ in observations})
+
+
+def _geometry_key(geom):
+    """Everything but `frames`, which is a property of the column, not the tile."""
+    return json.dumps(
+        {k: v
+         for k, v in geom.items()
+         if k != 'frames'}, sort_keys=True)
+
+
+def load_part(path):
+    """Read a part.yaml."""
+    with open(path) as f:
+        return xyaml.load(f)
+
+
+def load_grid(tiles_txt, pin_func_txt):
+    """Build a bare grid out of what generate_tiles.tcl dumps from Vivado.
+
+    The parser is the fuzzer's own, so a grid dumped for this tool and a grid
+    dumped inside 005-tilegrid are read exactly the same way.
+    """
+    generate = _import_generate_005()
+    return generate.make_database(
+        generate.load_tiles(tiles_txt),
+        generate.load_pin_functions(pin_func_txt))
+
+
+def _import_generate_005():
+    here = os.path.dirname(os.path.abspath(__file__))
+    path = os.path.join(
+        here, os.pardir, 'fuzzers', '005-tilegrid', 'generate.py')
+    spec = importlib.util.spec_from_file_location('generate_005', path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def diff_bits(left, right):
+    """Compare the `bits` of two grids, tile by tile and bus by bus.
+
+    Returns (Counter, [(tile_name, tile_type, bus, kind, left, right)]) where
+    kind is 'identical', 'differing', 'left-only' or 'right-only'.
+    """
+    counter = collections.Counter()
+    differences = []
+    for name in sorted(set(left) | set(right)):
+        if name not in left or name not in right:
+            counter['left-only-tile' if name in
+                    left else 'right-only-tile'] += 1
+            continue
+        lbits = left[name].get('bits', {})
+        rbits = right[name].get('bits', {})
+        tile_type = left[name]['type']
+        for bus in sorted(set(lbits) | set(rbits)):
+            if lbits.get(bus) == rbits.get(bus):
+                counter['identical'] += 1
+                continue
+            if bus in lbits and bus in rbits:
+                kind = 'differing'
+            elif bus in lbits:
+                kind = 'left-only'
+            else:
+                kind = 'right-only'
+            counter[kind] += 1
+            differences.append(
+                (name, tile_type, bus, kind, lbits.get(bus), rbits.get(bus)))
+    return counter, differences


### PR DESCRIPTION
# utils: derive a device tilegrid from its grid, and calibrate the law that does it

This is the derivation gate promised in #17: the second, Vivado-free route that
prjxray-db#15 used to check the fuzzed `xc7s25` model entry by entry, cleaned up
as a `utils/` tool so anyone can run it. @AssassinK786 — this is yours to use on
the `xc7s100` regeneration, and I would like your first review on it.

## What it is

`utils/tilegrid_derive.py` builds a device `tilegrid.json` out of a Vivado grid
dump plus the device models the database already holds. Every frame address has
the same shape:

```
baseaddr = (block_type << 23) | (bottom << 22) | (row << 17) | (column << 7)
```

and the pieces are all measurable from what is already committed: the column is
the rank of the tile's own configuration column among the grid columns carrying
an interconnect tile (with `INT_FEEDTHRU_2` standing in where the configuration
centre interrupts the fabric — that is why `xc7s25` declares 38 configuration
columns while carrying only 32 interconnect ones); which of those columns a tile
belongs to is a fixed per-tile-type grid_x delta; `bottom`/`row` come from
`part.yaml`; and `offset`/`words`/`frames` are a function of the tile type and of
where the tile sits inside its clock-region row.

Nothing in the tool is a constant somebody wrote down. Every delta and every
geometry is learned from device models that `005-tilegrid` produced against real
silicon, per family, because tile geometry does differ between families.

## What it is for

**A second opinion on the fuzzer.** Run both on a new device and compare. Where
they agree the model has been measured twice by methods that share nothing —
one from bitstream deltas, one from the grid and the rest of the database.
Where they disagree, one of them is wrong and the comparison names the tile.
That is exactly how prjxray-db#15 was checked: fuzzed and derived agreed on 5034
of 5041 entries, and each of the seven exceptions had a reason.

**A detector of models aimed at the wrong device.** The committed `xc7s25` and
`xc7s75` models were the `xc7s50` fabric for years. What caught them is the
first thing this tool does: count the interconnect columns in the grid and
compare against what the device's own `part.yaml` declares. 44 against 38 and 54
respectively, so it refuses the device instead of deriving nonsense — and
refuses to learn from it too.

## The gate

A law that cannot rebuild the models we already trust has no business building
one we cannot check, so:

```
utils/tilegrid_derive.py calibrate --database-dir database
```

leaves one device model out at a time, learns the law from the rest of its
family, rebuilds it from its grid alone and diffs it against the committed file.
No Vivado, no bitstreams, about a minute over the whole database. Against
prjxray-db at the merge of #15, **11 of the 17 device models come out byte for
byte identical, 500405 `bits` entries in all**:

| family | reproduced exactly | entries |
|---|---|---|
| artix7 | xc7a100t, xc7a50t | 29834 |
| kintex7 | xc7k70t, xc7k160t, xc7k325t, xc7k420t, xc7k480t | 287790 |
| spartan7 | xc7s50 | 10342 |
| zynq7 | xc7z030, xc7z045, xc7z100 | 172439 |

The other six are each accounted for, and the same command prints why:

| device | outcome | why |
|---|---|---|
| xc7vx485t | skipped | the only virtex7 device model; nothing to learn from |
| xc7z010 | refused | its PS7 swallows 24 configuration columns, so the column rule does not hold: 38 interconnect columns in the grid against 56 in `part.yaml` |
| xc7a200t | 220 entries missing | the only artix7 device with GTP transceivers mid-die; no other artix7 model can teach `GTP_*_MID_*` |
| xc7z020 | 159 entries missing | the only zynq7 device model with a right-hand high-range I/O column now that xc7z010 is refused; every reference it has puts those tiles on the left, so it cannot tell which side the interconnect is on, and does not guess |
| xc7s25 | 7 entries differ | six `*_SING` tiles differ in `alias.start_offset` alone (see below), plus the `MONITOR_BOT_FUJI2` no other spartan7 device has |
| xc7s100 | 7 entries differ | the fingerprint of the site-type bug #16 fixed — see below |

`utils/test_tilegrid_derive.py` runs that same calibration as a test with the
table written down, so a device model that starts differing in a *new* way fails
it. It skips when there is no database to calibrate against, since the
repository itself carries only the mapping files.

## Running it on xc7s100 today

This is the part that is directly useful for the regeneration. Point `derive` at
the committed model's own grid and diff:

```
utils/tilegrid_derive.py derive --db-root database/spartan7 \
    --part xc7s100fgga676-1 --grid database/spartan7/xc7s100/tilegrid.json \
    --output xc7s100-derived.json
utils/tilegrid_derive.py compare database/spartan7/xc7s100/tilegrid.json \
    xc7s100-derived.json --labels committed derived
```

```
19181 bits entries identical, 1 differing, 0 only in committed, 6 only in derived
    CFG_CENTER_MID                           right-only   1
    CLK_BUFG_BOT_R                           differing    1
    LIOB33                                   right-only   5

  CLK_BUFG_BOT_R_X73Y100 CLB_IO_CLK (differing)
    committed {"baseaddr": "0x00400E80", "frames": 30, "offset": 98, "words": 3}
    derived  {"baseaddr": "0x00400E80", "frames": 30, "offset": 93, "words": 8}
```

Three findings: two we already knew — the 98-against-93 offset and the
`CFG_CENTER_MID` gap that makes `checkdb` fail on this part today — and one that
had not been listed before, **five `LIOB33` tiles with no frame address at
all**: `LIOB33_X0Y31`, `X0Y33`, `X0Y35`, `X0Y37`, `X0Y47`. Those are
exactly the five whose sites the committed grid types as plain `IOB33` instead of
`IOB33M`/`IOB33S`, because the ROI design had bound them before the grid was
read; `iob/top.py` selects by site type, so it skipped them. A regenerated model
on the pristine grid should have all three gone, and this comparison is a cheap
way to confirm it.

## Two rules that make it a check rather than a guess

**It never invents.** A tile type no reference model of the family carries gets
no address at all, and `derive` says so at the end of its run.
`--cross-family-fallback` will borrow such a geometry from the other families
and counts those entries separately: worth having (on `xc7z020` it fills the
whole right-hand I/O column, 156 entries, all matching the committed model) and
worth being careful with (it also addresses hard blocks such as `GTP_*` and
`PCIE_*` that the committed models deliberately leave alone), which is why it is
off by default.

**When two reference models contradict each other, it says so, with the vote.**
The family majority wins; if the family is split evenly, the models of the other
families break the tie; if nothing breaks it, `derive` stops rather than
deciding quietly. Deriving `xc7s25` from both its siblings prints:

```
CLK_BUFG_BOT_R row_position=47 CLB_IO_CLK -- resolved by other families
    {"frames": 30, "offset": 93, "words": 8} xc7s50 (+13 elsewhere)
    {"frames": 30, "offset": 98, "words": 3} xc7s100
```

which is the fingerprinted model being outvoted by the thirteen that agree with
the fuzzer. The family is the right scope for the law and the rest of the
database is a tiebreaker rather than a source, and that is measured, not
assumed: even the soft version of borrowing from other families — only for tile
types the family cannot teach at all — takes the calibration from 11 exact
models down to 7, because it starts addressing hard blocks the committed models
leave alone.

## One thing this turned up that needs a decision

The six `xc7s25` differences are one issue, and it is a database inconsistency
rather than a limitation of the law: the upper `*_SING` tiles
(`LIOB33_SING`, `LIOI3_SING`, `RIOB33_SING`, `RIOI3_SING`) carry
`alias.start_offset: 2` in the newly fuzzed `xc7s25` model and `0` in every
model committed before it. `generate_full.py` has written 2 since the VC707 fix,
so the newer model is the one that matches the current fuzzer; the fourteen
older ones were generated before it. It is a one-line change per device, but it
touches every device model in the database, so it wants to be its own decision
rather than a side effect of this PR — @hansfbaier, how would you like it
handled?

## The commits

- `utils: derive a device tilegrid from its grid, and calibrate the law that
  does it` — `utils/tilegrid_model.py` (the law), `utils/tilegrid_derive.py`
  (`calibrate` / `derive` / `compare`), `utils/test_tilegrid_derive.py` (the
  gate as a test).
- `utils: run 005-tilegrid's grid dump on its own` — `utils/dump_grid.sh`, a
  wrapper around `generate_tiles.tcl`, not a second copy of it. Since #16 reads
  the grid off a device with nothing placed on it, that tcl needs no ROI design,
  no fuzzer build and no settings file for the part, which is exactly the
  position you are in with a part the database does not have yet. Checked on
  `xc7s25csga324-1` with Vivado 2026.1: byte identical output to a standalone
  dump of the same part.
- `docs: the tilegrid derivation, its calibration gate and its limits` —
  `docs/db_dev_process/tilegrid_derivation.rst`, next to the existing guide for
  adding a device, with the flow dump → derive → fuzz → compare.

Stdlib plus what prjxray already uses (`utils/xyaml`, `utils/xjson`,
`prjxray.util`); the grid parser is `fuzzers/005-tilegrid/generate.py`'s own, so
a grid read by this tool and a grid read inside the fuzzer are read identically.
