### PR TITLE
utils: settle reference ties by rule, not by argument order

### DIFF
--- a/docs/db_dev_process/tilegrid_derivation.rst
+++ b/docs/db_dev_process/tilegrid_derivation.rst
@@ -120,16 +120,36 @@ Where the references disagree
 -----------------------------
 
 Two reference models can contradict each other -- that is what a wrong model
-looks like from the inside.  The tool resolves a disagreement by counting
-devices: the majority of the family wins; if the family is split evenly, the
-models of the *other* families break the tie; if nothing breaks it, the first
-``--reference`` given wins and the conflict is reported as ``arbitrary``,
-which ``derive`` refuses to proceed on unless told to.  Whichever way it goes,
-the disagreement is printed with the vote::
+looks like from the inside.  The tool settles a disagreement in four steps:
+
+1. the geometry the most devices of the family agree on wins;
+2. if the family is split evenly, a reference named with
+   ``--prefer-reference`` wins outright.  An explicit choice beats the proxy
+   votes below, which can be *stale*: on the ``*_SING`` tiles'
+   ``alias.start_offset``, every device model committed before ``xc7s25``
+   still votes the 0 that ``generate_full.py`` has not written since the
+   VC707 fix.  A preference never overrides a majority of the family itself
+   -- narrow ``--reference`` for that;
+3. with nothing preferred, the models of the *other* families break the tie;
+4. if nothing breaks it, the alphabetically first of the tied references
+   wins -- a fixed rule, never the order the references happened to be given
+   in.  The conflict is reported as ``arbitrary``, and ``derive`` refuses to
+   proceed on a geometry its grid actually uses unless told to, with
+   ``--allow-reference-conflicts``; then it prints each such pick, what won,
+   and what the alternative was.
+
+Whichever way it goes, the disagreement is printed with the vote::
 
     CLK_BUFG_BOT_R row_position=47 CLB_IO_CLK -- resolved by other families
         {"frames": 30, "offset": 93, "words": 8} xc7s50 (+13 elsewhere)
         {"frames": 30, "offset": 98, "words": 3} xc7s100
+
+Mind that the tie-breaking model is only as complete as the database you
+point at: run ``derive`` against a family-only checkout and step 3 has nobody
+left to ask, so every family tie lands on step 4.  The pick is still
+deterministic and is still printed, but if you *know* which reference to
+trust -- the freshly fuzzed one, say -- this is what ``--prefer-reference``
+is for.
 
 Adding a device
 ---------------

--- a/utils/test_tilegrid_derive.py
+++ b/utils/test_tilegrid_derive.py
@@ -241,6 +241,61 @@ class TestLaw(unittest.TestCase):
         model.apply(target, target_part)
         self.assertEqual(target['DSP_R_X0Y10']['bits'], {})
 
+    def tied_model(self, learn_order, prefer=None):
+        """Two references that disagree on every geometry, learnt in the
+        given order; the resolved model."""
+        model = tilegrid_model.Model()
+        for device, offset in learn_order:
+            grid, part = synthetic_device(columns=3)
+            address_synthetic(grid, part)
+            for tile in grid.values():
+                tile['bits']['CLB_IO_CLK']['offset'] = offset
+            model.learn(device, grid, part)
+        model.resolve(prefer=prefer)
+        return model
+
+    def test_a_tie_of_two_goes_to_the_first_alphabetically(self):
+        """A tie no vote can settle is deterministic: the alphabetically
+        first tied reference wins, in whichever order the references were
+        learnt."""
+        for learn_order in (
+            [('ref-b', 100), ('ref-a', 200)],
+            [('ref-a', 200), ('ref-b', 100)],
+        ):
+            model = self.tied_model(learn_order)
+            self.assertTrue(model.conflicts)
+            self.assertEqual(
+                {c.resolution
+                 for c in model.conflicts}, {'arbitrary'})
+            self.assertEqual(
+                len(model.unresolved_conflicts()), len(model.conflicts))
+            for geometry in model.geometry.values():
+                self.assertEqual(geometry['offset'], 200)  # ref-a's
+            self.assertIn('ref-a', model.conflicts[0].describe())
+
+    def test_preferred_reference_wins_a_tie(self):
+        """A named reference beats the deterministic pick, and is recorded."""
+        model = self.tied_model(
+            [('ref-b', 100), ('ref-a', 200)], prefer=['ref-b'])
+        self.assertEqual(
+            {c.resolution
+             for c in model.conflicts}, {'preferred reference'})
+        self.assertEqual(model.unresolved_conflicts(), [])
+        for geometry in model.geometry.values():
+            self.assertEqual(geometry['offset'], 100)
+
+    def test_preferred_references_that_split_settle_nothing(self):
+        """A preference naming both sides of the tie settles nothing, and
+        one naming neither side is ignored."""
+        for prefer in (['ref-a', 'ref-b'], ['ref-c']):
+            model = self.tied_model(
+                [('ref-b', 100), ('ref-a', 200)], prefer=prefer)
+            self.assertEqual(
+                {c.resolution
+                 for c in model.conflicts}, {'arbitrary'})
+            for geometry in model.geometry.values():
+                self.assertEqual(geometry['offset'], 200)
+
 
 @unittest.skipIf(database_dir() is None, 'no database with device models')
 class TestCalibration(unittest.TestCase):

--- a/utils/tilegrid_derive.py
+++ b/utils/tilegrid_derive.py
@@ -115,12 +115,17 @@ def learn(model, family_dir, device):
     return model.learn(device, grid, part_yaml)
 
 
-def learn_references(family_dir, references, elsewhere=None):
-    """Learn the law of one family from the named device models."""
+def learn_references(family_dir, references, elsewhere=None, prefer=None):
+    """Learn the law of one family from the named device models.
+
+    `prefer` names references that win a family tie outright; the
+    calibration gate passes none, because a gate with a preference is
+    measuring the preference.
+    """
     model = tilegrid_model.Model()
     for device in references:
         learn(model, family_dir, device)
-    model.resolve(elsewhere)
+    model.resolve(elsewhere, prefer)
     return model
 
 
@@ -323,6 +328,14 @@ def cmd_derive(args):
         print(
             'warning: %s is the fabric %s already maps to; deriving it from '
             'itself proves nothing' % (own, args.part))
+    prefer = args.prefer_reference
+    not_references = [d for d in prefer if d not in references]
+    if not_references:
+        print(
+            'ERROR: --prefer-reference %s, but the references are: %s' %
+            (' '.join(not_references), ' '.join(references) or 'none'),
+            file=sys.stderr)
+        return 1
     part_yaml = tilegrid_model.load_part(
         os.path.join(family_dir, args.part, PART_YAML))
 
@@ -334,7 +347,7 @@ def cmd_derive(args):
 
     family_models = learn_families(database_dir)
     elsewhere = learn_elsewhere(family_models, family)
-    model = learn_references(family_dir, references, elsewhere)
+    model = learn_references(family_dir, references, elsewhere, prefer)
     print('law learnt from %s' % ' '.join(model.references))
     print_rejected(model)
     print_conflicts(model)
@@ -360,14 +373,23 @@ def cmd_derive(args):
         c for c in model.unresolved_conflicts()
         if (c.tile_type, c.row_position, c.bus) in used
     ]
-    if unsettled and not args.allow_reference_conflicts:
+    if unsettled:
+        if not args.allow_reference_conflicts:
+            print(
+                'ERROR: %d tile geometries this grid uses are ones the '
+                'reference models disagree on and no vote could settle; '
+                'narrow --reference, name the one you trust with '
+                '--prefer-reference, or pass --allow-reference-conflicts to '
+                'take the deterministic pick.' % len(unsettled),
+                file=sys.stderr)
+            return 1
         print(
-            'ERROR: %d tile geometries this grid uses are ones the reference '
-            'models disagree on and no vote could settle; narrow --reference, '
-            'or pass --allow-reference-conflicts to take the first one given.'
-            % len(unsettled),
-            file=sys.stderr)
-        return 1
+            'WARNING: %d tile geometries this grid uses rest on a pick no '
+            'vote settled, taken because --allow-reference-conflicts was '
+            'given:' % len(unsettled))
+        for conflict in unsettled:
+            for line in conflict.describe().split('\n'):
+                print('    %s' % line)
 
     report = model.apply(
         grid, part_yaml, elsewhere if args.cross_family_fallback else None)
@@ -471,6 +493,14 @@ def main():
         'separated list is accepted. Defaults to every device model of the '
         'family except the one this part is already a part of.')
     derive.add_argument(
+        '--prefer-reference',
+        action='append',
+        default=[],
+        help='reference device whose geometry wins when the family vote '
+        'ties, before the other families are asked; repeatable, and a comma '
+        'separated list is accepted. Does not override a majority of the '
+        'family; narrow --reference for that.')
+    derive.add_argument(
         '--output', required=True, help='tilegrid.json to write')
     derive.add_argument(
         '--cross-family-fallback',
@@ -480,7 +510,9 @@ def main():
     derive.add_argument(
         '--allow-reference-conflicts',
         action='store_true',
-        help='derive even where the reference models disagree')
+        help='derive even where the reference models disagree and no vote '
+        'could settle it; the pick is deterministic (the alphabetically '
+        'first tied reference) and is printed')
     derive.set_defaults(func=cmd_derive)
 
     compare = commands.add_parser(
@@ -506,6 +538,10 @@ def main():
         for reference in args.reference:
             flat.extend(r for r in reference.split(',') if r)
         args.reference = flat
+        flat = []
+        for preferred in args.prefer_reference:
+            flat.extend(r for r in preferred.split(',') if r)
+        args.prefer_reference = flat
     return args.func(args)
 
 

--- a/utils/tilegrid_model.py
+++ b/utils/tilegrid_model.py
@@ -200,16 +200,32 @@ class Conflict(collections.namedtuple(
 
     `alternatives` is a list of (geometry, [devices], outside_votes), the one
     that won first.  `resolution` says how it won: 'majority' (most devices in
-    the family), 'other families' (the family was split evenly and the models
-    of the other families broke the tie) or 'arbitrary' (nothing broke the
-    tie, so the first reference given won and the answer is a guess).
+    the family), 'preferred reference' (the family was split evenly and a
+    reference named with --prefer-reference was one of the tied ones),
+    'other families' (the family was split evenly and the models of the
+    other families broke the tie) or 'arbitrary' (nothing broke the tie, so
+    the alphabetically first tied reference won -- a fixed rule, never the
+    order the references were given in).
     """
 
     def describe(self):
-        lines = [
-            '%s row_position=%d %s -- resolved by %s' %
-            (self.tile_type, self.row_position, self.bus, self.resolution)
-        ]
+        winner_devices = self.alternatives[0][1]
+        if self.resolution == 'arbitrary':
+            headline = (
+                '%s row_position=%d %s -- no vote settled it; %s wins as '
+                'the alphabetically first tied reference' % (
+                    self.tile_type, self.row_position, self.bus,
+                    winner_devices[0]))
+        elif self.resolution == 'preferred reference':
+            headline = (
+                '%s row_position=%d %s -- settled by the preferred '
+                'reference (%s)' % (
+                    self.tile_type, self.row_position, self.bus,
+                    ' '.join(winner_devices)))
+        else:
+            headline = '%s row_position=%d %s -- resolved by %s' % (
+                self.tile_type, self.row_position, self.bus, self.resolution)
+        lines = [headline]
         for geom, devices, outside in self.alternatives:
             lines.append(
                 '    %-40s %s%s' % (
@@ -269,7 +285,7 @@ class Model:
         self.conflicts = []
         return True, 'ok'
 
-    def resolve(self, tiebreaker=None):
+    def resolve(self, tiebreaker=None, prefer=None):
         """Turn the observations into one geometry per key.
 
         Observations that differ only in `frames` are the same geometry seen
@@ -278,11 +294,19 @@ class Model:
         reference models, and it is resolved in this order:
 
         1. the geometry the most devices of the family agree on;
-        2. if the family is split evenly, the geometry the models in
-           `tiebreaker` agree on -- pass a model built from the *other*
-           families, so a device never gets to vote on itself;
-        3. if that is split too, the first reference given wins and the
-           conflict is marked 'arbitrary'.
+        2. if the family is split evenly and `prefer` names one of the tied
+           references, that reference wins outright -- an explicit choice
+           beats the proxy votes below, which can be stale (every older
+           model may carry a value the current fuzzer no longer writes), but
+           it does not beat a majority of the family itself; narrow the
+           reference list for that;
+        3. with nothing preferred, the geometry the models in `tiebreaker`
+           agree on -- pass a model built from the *other* families, so a
+           device never gets to vote on itself;
+        4. if that is split too, the alphabetically first of the tied
+           references wins -- a fixed rule, never the order the references
+           happened to be given in -- and the conflict is marked
+           'arbitrary'.
 
         Every disagreement is recorded in self.conflicts whichever way it
         went, because a model standing alone against the rest of the database
@@ -304,12 +328,23 @@ class Model:
             leaders = [m for m in merged if len(m[1]) == top]
             resolution = 'majority'
             if len(leaders) > 1:
-                best_outside = max(m[2] for m in leaders)
-                outside_leaders = [m for m in leaders if m[2] == best_outside]
-                resolution = (
-                    'other families' if best_outside
-                    and len(outside_leaders) == 1 else 'arbitrary')
-                leaders = outside_leaders
+                preferred = [
+                    m for m in leaders
+                    if prefer and any(d in prefer for d in m[1])
+                ]
+                if len(preferred) == 1:
+                    leaders = preferred
+                    resolution = 'preferred reference'
+                else:
+                    best_outside = max(m[2] for m in leaders)
+                    leaders = [m for m in leaders if m[2] == best_outside]
+                    if best_outside and len(leaders) == 1:
+                        resolution = 'other families'
+                    else:
+                        # Nothing broke the tie: a fixed rule, not the order
+                        # the references happened to be learnt in.
+                        leaders.sort(key=lambda m: m[1])
+                        resolution = 'arbitrary'
             winner = leaders[0]
             self.geometry[key] = winner[0]
             if len(merged) > 1:


### PR DESCRIPTION
# utils: settle reference ties by rule, not by argument order

Follow-up to #18, from the review nit @AssassinK786 left there (thanks --
it was correct): when the reference models disagree on a tile geometry, the
family vote ties, and the other families cannot break the tie either, the
tool silently took the first reference listed. The answer then depended on
argument order, not on any property of the references.

## What was measured first

The case behind the nit is the xc7s100 derivation of prjxray-db#17 (the
`*_SING` tiles' `alias.start_offset`, 2 in the freshly fuzzed xc7s25, 0 in
every older model). The same `derive` command answers differently depending
on things that should not decide a value:

| database it runs against | answer | how |
|---|---|---|
| full database | 0 | the twelve older models outvote the fresh one |
| spartan7-only checkout | 2 | nobody left to break the tie, so the order of `--reference` decided |

Note the full-database answer is the *stale* one: every model committed
before xc7s25 still votes the value `generate_full.py` has not written
since the VC707 fix. So neither existing step is satisfactory here -- one is
order-dependent, the other can be a stale majority.

## What changes

- `derive` gains `--prefer-reference <device>`: when the family vote ties,
  a reference the user named wins outright, before the other families are
  asked -- an explicit choice beats a proxy vote. It never overrides a
  majority of the family itself (narrow `--reference` for that), and it is
  printed as `settled by the preferred reference (...)`.
- Remaining ties go to the alphabetically first tied reference -- a fixed
  rule with the same answer in every checkout and argument order -- and the
  output says exactly that. `derive` also prints a WARNING for every such
  pick its grid actually uses when `--allow-reference-conflicts` lets it
  proceed, so the guess is never silent again.

The calibration gate takes no preference by construction: a gate with a
preference is measuring the preference.

## Gate impact: none, measured

No calibration on the full database ever reaches the arbitrary step (zero
firings; the ten disagreements it hits are all settled by the other
families), so the run before and the run after are byte-identical:

```
summary: 17 device models, 4 differs, 11 exact, 1 refused, 1 skipped;
         500405 bits entries reproduced byte for byte
```

And the real case, with this branch: `derive --prefer-reference xc7s25`
against the **full** database reproduces prjxray-db#17's tilegrid byte for
byte (same sha256), with no `--allow-reference-conflicts` and no dependence
on checkout completeness or argument order. Reversing `--reference xc7s50
--reference xc7s25` yields the same file.

New synthetic tests cover the tie of two in both learn orders, the named
preference, and the preference that names both sides of the tie (it settles
nothing). Docs updated in `docs/db_dev_process/tilegrid_derivation.rst`.
